### PR TITLE
Add UI acceptance tests for User Management

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -46,7 +46,7 @@ pipeline:
       matrix:
         NEED_INSTALL_APP: true
 
-  run-acceptance-tests:
+  webui-acceptance-tests:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
@@ -56,15 +56,14 @@ pipeline:
       - SRV_HOST_PORT=80
       - REMOTE_FED_SRV_HOST_NAME=federated
       - REMOTE_FED_SRV_HOST_PORT=80
-      - SKELETON_DIR=/var/www/owncloud/tests/ui/skeleton
+      - SKELETON_DIR=/var/www/owncloud/tests/acceptance/webUISkeleton
       - SELENIUM_PORT=4444
       - PLATFORM=Linux
-      - TEST_EXTERNAL_USER_BACKENDS=true
     commands:
       - cd /var/www/owncloud
       - chown www-data * -R
-      - chmod 777 /var/www/owncloud/tests/ui/filesForUpload -R
-      - bash tests/travis/start_ui_tests.sh --remote --tags '@TestAlsoOnExternalUserBackend&&~@skipOnLDAP'
+      - chmod 777 /var/www/owncloud/tests/acceptance/filesForUpload -R
+      - bash tests/travis/start_ui_tests.sh --remote --config /var/www/owncloud/apps/user_management/tests/acceptance/config/behat.yml
     when:
       matrix:
         TEST_SUITE: acceptance
@@ -116,7 +115,7 @@ services:
     pull: true
     environment:
       - APACHE_WEBROOT=/var/www/owncloud/
-    command: [ "/usr/local/bin/apachectl", "-e", "debug" , "-D" , "FOREGROUND" ]
+    command: [ "/usr/local/bin/apachectl", "-e", "debug", "-D", "FOREGROUND" ]
     when:
       matrix:
         TEST_SUITE: acceptance
@@ -126,7 +125,7 @@ services:
     pull: true
     environment:
       - APACHE_WEBROOT=/var/www/owncloud/
-    command: [ "/usr/local/bin/apachectl", "-e", "debug" , "-D" , "FOREGROUND" ]
+    command: [ "/usr/local/bin/apachectl", "-e", "debug", "-D", "FOREGROUND" ]
     when:
       matrix:
         TEST_SUITE: acceptance
@@ -187,20 +186,30 @@ matrix:
      NEED_INSTALL_APP: true
 
 #acceptance tests
+   - TEST_SUITE: acceptance
+     OC_VERSION: master
+     PHP_VERSION: 7.1
+     NEED_SERVER: true
+     NEED_INSTALL_APP: true
+     BEHAT_SUITE: webUIManageQuota
+
+   - TEST_SUITE: acceptance
+     OC_VERSION: master
+     PHP_VERSION: 7.1
+     NEED_SERVER: true
+     NEED_INSTALL_APP: true
+     BEHAT_SUITE: webUIManageUsersGroups
+#
 #   - TEST_SUITE: acceptance
-#     OC_VERSION: daily-master-qa
+#     OC_VERSION: stable10
 #     PHP_VERSION: 7.1
 #     NEED_SERVER: true
 #     NEED_INSTALL_APP: true
+#     BEHAT_SUITE: webUIManageQuota
 #
 #   - TEST_SUITE: acceptance
-#     OC_VERSION: daily-stable10-qa
-#     PHP_VERSION: 5.6
+#     OC_VERSION: stable10
+#     PHP_VERSION: 7.1
 #     NEED_SERVER: true
 #     NEED_INSTALL_APP: true
-#
-#   - TEST_SUITE: acceptance
-#     OC_VERSION: daily-stable10-qa
-#     PHP_VERSION: 7.0
-#     NEED_SERVER: true
-#     NEED_INSTALL_APP: true
+#     BEHAT_SUITE: webUIManageUsersGroups

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,6 +24,9 @@ pipeline:
     pull: true
     commands:
       - tail -f /var/www/owncloud/data/owncloud.log
+    when:
+      matrix:
+        NEED_SERVER: true
 
   install-app:
     image: owncloudci/php:${PHP_VERSION}

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -1,0 +1,43 @@
+default:
+  autoload:
+    '': %paths.base%/../features/bootstrap
+  extensions:
+    SensioLabs\Behat\PageObjectExtension: ~
+
+  suites:
+    webUIManageQuota:
+      paths:
+        - %paths.base%/../features/webUIManageQuota
+      context: &common_webui_suite_context
+        parameters:
+          ocPath: apps/testing/api/v1/occ
+          adminUsername: admin
+          adminPassword: admin
+          regularUserPassword: 123456
+      contexts:
+        - WebUIUsersContext:
+        - FeatureContext: &common_feature_context_params
+            baseUrl:  http://localhost:8080/ocs/
+            adminUsername: admin
+            adminPassword: admin
+            regularUserPassword: 123456
+            mailhogUrl: http://127.0.0.1:8025/api/v2/messages
+            ocPath: ../../../../
+        - WebUIGeneralContext:
+        - WebUILoginContext:
+        - WebUIUserContext:
+        - WebUISharingContext:
+        - WebUIFilesContext:
+
+    webUIManageUsersGroups:
+      paths:
+        - %paths.base%/../features/webUIManageUsersGroups
+      context: *common_webui_suite_context
+      contexts:
+        - WebUIUsersContext:
+        - FeatureContext: *common_feature_context_params
+        - WebUIGeneralContext:
+        - WebUILoginContext:
+        - WebUIUserContext:
+        - WebUISharingContext:
+        - WebUIFilesContext:

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2017 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+require_once 'bootstrap.php';
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Exception\ExpectationException;
+use Behat\MinkExtension\Context\RawMinkContext;
+use Page\UsersPage;
+
+/**
+ * WebUI Users context.
+ */
+class WebUIUsersContext extends RawMinkContext implements Context {
+
+	private $usersPage;
+
+	/**
+	 *
+	 * @var FeatureContext
+	 */
+	private $featureContext;
+
+	/**
+	 * WebUIUsersContext constructor.
+	 *
+	 * @param UsersPage $usersPage
+	 */
+	public function __construct(UsersPage $usersPage) {
+		$this->usersPage = $usersPage;
+	}
+
+	/**
+	 * @When the user/administrator browses to the users page
+	 * @Given the user/administrator has browsed to the users page
+	 *
+	 * @return void
+	 */
+	public function theUserBrowsesToTheUsersPage() {
+		$this->usersPage->open();
+		$this->usersPage->waitTillPageIsLoaded($this->getSession());
+	}
+
+	/**
+	 * @When the administrator sets/changes the quota of user :username to :quota using the webUI
+	 * @Given the administrator has set/changed the quota of user :username to :quota using the webUI
+	 *
+	 * @param string $username
+	 * @param string $quota
+	 * 
+	 * @return void
+	 */
+	public function theAdministratorSetsTheQuotaOfUserUsingTheWebUI($username, $quota) {
+		$this->usersPage->setQuotaOfUserTo($username, $quota, $this->getSession());
+	}
+
+	/**
+	 * @When /^the administrator (attempts to create|creates) a user with the name "([^"]*)" (?:and )?the password "([^"]*)"(?: and the email "([^"]*)")?(?: that is a member of these groups)? using the webUI$/
+	 *
+	 * @param string $attemptTo
+	 * @param string $username
+	 * @param string $password
+	 * @param string $email
+	 * @param TableNode $groupsTable table of groups with a heading | group |
+	 * 
+	 * @return void
+	 */
+	public function theAdminCreatesAUserUsingTheWebUI(
+		$attemptTo, $username, $password, $email=null, TableNode $groupsTable=null
+	) {
+		if (!is_null($groupsTable)) {
+			$groups = $groupsTable->getColumn(0);
+			//get rid of the header
+			unset($groups[0]);
+		} else {
+			$groups = null;
+		}
+		$this->usersPage->createUser(
+			$this->getSession(), $username, $password, $email, $groups
+		);
+
+		$shouldHaveBeenCreated = ($attemptTo === "");
+
+		$this->featureContext->addUserToCreatedUsersList(
+			$username, $password, "", $email, $shouldHaveBeenCreated
+		);
+		if (is_array($groups)) {
+			foreach ($groups as $group) {
+				$this->featureContext->addGroupToCreatedGroupsList($group);
+			}
+		}
+	}
+
+	/**
+	 * 
+	 * @When the administrator deletes the group named :name using the webUI
+	 *
+	 * @param string $name
+	 * 
+	 * @return void
+	 */
+	public function theAdminDeletesTheGroupUsingTheWebUI($name) {
+		$this->usersPage->deleteGroup($name, $this->getSession());
+		$this->featureContext->deleteGroupFromCreatedGroupsList($name);
+	}
+
+	/**
+	 * @When the administrator deletes these groups using the webUI:
+	 * expects a table of groups with the heading "groupname"
+	 *
+	 * @param TableNode $table
+	 * 
+	 * @return void
+	 */
+	public function theAdminDeletesTheseGroupsUsingTheWebUI(TableNode $table) {
+		foreach ($table as $row) {
+			$this->theAdminDeletesTheGroupUsingTheWebUI($row['groupname']);
+		}
+	}
+
+	
+	/**
+	 * @Then the group name :groupName should be listed on the webUI
+	 *
+	 * @param string $groupName
+	 * 
+	 * @return void
+	 */
+	public function theGroupNameShouldBeListed($groupName) {
+		$groups = $this->usersPage->getAllGroups();
+		PHPUnit_Framework_Assert::assertContains(
+			$groupName, $groups, "Expected '" . $groupName . "' does not exist"
+		);
+	}
+
+	/**
+	 * @Then the group name :name should not be listed on the webUI
+	 *
+	 * @param string $name
+	 * 
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theGroupNamedShouldNotBeListedOnTheWebUI($name) {
+		if (in_array($name, $this->usersPage->getAllGroups(), true)) {
+			throw new Exception("group '" . $name . "' is listed but should not");
+		}
+	}
+
+	/**
+	 * @Then /^these groups should (not|)\s?be listed on the webUI:$/
+	 * expects a table of groups with the heading "groupname"
+	 *
+	 * @param string $shouldOrNot (not|)
+	 * @param TableNode $table
+	 * 
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theseGroupsShouldBeListedOnTheWebUI($shouldOrNot, TableNode $table) {
+		$should = ($shouldOrNot !== "not");
+		$groups = $this->usersPage->getAllGroups();
+		foreach ($table as $row) {
+			if (in_array($row['groupname'], $groups, true) !== $should) {
+				throw new Exception(
+					"group '" . $row['groupname'] .
+					"' is" . ($should ? " not" : "") .
+					" listed but should" . ($should ? "" : " not") . " be"
+				);
+			}
+		}
+	}
+
+	/**
+	 * @When the user/administrator reloads the users page
+	 * @Given the user/administrator has reloaded the users page
+	 *
+	 * @return void
+	 */
+	public function theUserReloadsTheUsersPage() {
+		$this->getSession()->reload();
+		$this->usersPage->waitTillPageIsLoaded($this->getSession());
+	}
+
+	/**
+	 * @Then the quota of user :username should be set to :quota on the webUI
+	 *
+	 * @param string $username
+	 * @param string $quota
+	 * 
+	 * @return void
+	 * @throws ExpectationException
+	 */
+	public function quotaOfUserShouldBeSetToOnTheWebUI($username, $quota) {
+		$setQuota = $this->usersPage->getQuotaOfUser($username);
+		if ($setQuota !== $quota) {
+			throw new ExpectationException(
+				'Users quota is set to "' . $setQuota . '" expected "' .
+				$quota . '"', $this->getSession()
+			);
+		}
+	}
+
+	/**
+	 * This will run before EVERY scenario.
+	 *
+	 * @BeforeScenario @webUI
+	 *
+	 * @param BeforeScenarioScope $scope
+	 * 
+	 * @return void
+	 */
+	public function before(BeforeScenarioScope $scope) {
+		// Get the environment
+		$environment = $scope->getEnvironment();
+		// Get all the contexts you need in this context
+		$this->featureContext = $environment->getContext('FeatureContext');
+	}
+
+	/**
+	 * @When the administrator adds group :groupName using the webUI
+	 *
+	 * @param string $groupName
+	 * 
+	 * @return void
+	 */
+	public function theAdminAddsGroupUsingTheWebUI($groupName) {
+		$this->usersPage->addGroup($groupName, $this->getSession());
+	}
+}

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <info@jankaritech.com>
+ * @copyright Copyright (c) 2017 Artur Neumann info@jankaritech.com
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+require __DIR__ . '/../../../../../../lib/base.php';
+require __DIR__ . '/../../../../../../lib/composer/autoload.php';
+
+$classLoader = new \Composer\Autoload\ClassLoader();
+$classLoader->addPsr4(
+	"", __DIR__ . "/../../../../../../tests/acceptance/features/bootstrap", true
+);
+$classLoader->addPsr4(
+	"Page\\", __DIR__ . "/../../../../../../tests/acceptance/features/lib", true
+);
+$classLoader->addPsr4("Page\\", __DIR__ . "/../lib", true);
+$classLoader->addPsr4(
+	"TestHelpers\\", __DIR__ . "/../../../../../../tests/TestHelpers", true
+);
+$classLoader->register();

--- a/tests/acceptance/features/lib/UserPageElement/GroupList.php
+++ b/tests/acceptance/features/lib/UserPageElement/GroupList.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2017 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Page\UserPageElement;
+
+use Behat\Mink\Element\NodeElement;
+use Page\OwncloudPage;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+
+/**
+ * The list of groups
+ *
+ */
+class GroupList extends OwncloudPage {
+
+	/**
+	 * @var NodeElement of this element
+	 */
+	protected $groupListElement;
+	protected $allGroupsXpath = "//li[@class='isgroup']";
+	protected $groupLiXpath = "//li[@data-gid=%s]";
+	protected $deleteBtnXpath = "//a[@class='action delete']";
+	protected $addGroupXpath = '//span[text()[normalize-space()="Add Group"]]';
+	protected $addNewGroupInputBoxId = 'newgroupname';
+	protected $addNewGroupButtonXpath = '//input[@class="button icon-add"]';
+
+	/**
+	 * sets the NodeElement for the current group list
+	 * a little bit like __construct() but as we access this "sub-page-object"
+	 * from an other Page Object by $this->getPage("OwncloudPageElement\\GroupList")
+	 * there is no real __construct() that can take arguments
+	 *
+	 * @param \Behat\Mink\Element\NodeElement $groupListElement
+	 *
+	 * @return void
+	 */
+	public function setElement(NodeElement $groupListElement) {
+		$this->groupListElement = $groupListElement;
+	}
+
+	/**
+	 * 
+	 * @param string $name
+	 *
+	 * @throws ElementNotFoundException
+	 * @return \Behat\Mink\Element\NodeElement
+	 */
+	public function selectGroup($name) {
+		$name = $this->quotedText($name);
+		$xpathLocator = sprintf($this->groupLiXpath, $name);
+		$groupLi = $this->groupListElement->find(
+			"xpath", $xpathLocator
+		);
+		if (is_null($groupLi)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $xpathLocator " .
+				"could not find group list element"
+			);
+		}
+		$groupLi->click();
+		return $groupLi;
+	}
+
+	/**
+	 * deletes a group in the UI
+	 * 
+	 * @param string $name
+	 *
+	 * @throws ElementNotFoundException
+	 * @return void
+	 */
+	public function deleteGroup($name) {
+		$groupLi = $this->selectGroup($name);
+		$deleteButton = $groupLi->find("xpath", $this->deleteBtnXpath);
+		if (is_null($deleteButton)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->deleteBtnXpath " .
+				"could not find delete button"
+			);
+		}
+		$deleteButton->click();
+	}
+
+	/**
+	 * 
+	 * @param string  $groupName
+	 *
+	 * @throws ElementNotFoundException
+	 * @return void
+	 */
+	public function addGroup($groupName) {
+		$addLink = $this->find("xpath", $this->addGroupXpath);
+		if (is_null($addLink)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->addGroupXpath " .
+				"could not find add group link"
+			);
+		}
+		$addLink->click();
+		$this->fillField($this->addNewGroupInputBoxId, $groupName);
+		$addButton = $this->find("xpath", $this->addNewGroupButtonXpath);
+		if (is_null($addButton)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->addNewGroupButtonXpath " .
+				"could not find add group button"
+			);
+		}
+		$addButton->click();
+	}
+
+	/**
+	 * returns all group names in an array
+	 * 
+	 * @return string[]
+	 */
+	public function namesToArray() {
+		$allGroupElements = $this->groupListElement->findAll(
+			"xpath", $this->allGroupsXpath
+		);
+		$allGroups = [];
+		foreach ($allGroupElements as $element) {
+			$allGroups[] = $this->getTrimmedText($element);
+		}
+		return $allGroups;
+	}
+}
+	

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -1,0 +1,411 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Artur Neumann <artur@jankaritech.com>
+ * @copyright Copyright (c) 2017 Artur Neumann artur@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Page;
+
+use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Session;
+use Page\UserPageElement\GroupList;
+use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+use WebDriver\Exception\NoSuchElement;
+
+/**
+ * Users page.
+ */
+class UsersPage extends OwncloudPage {
+
+	/**
+	 *
+	 * @var string $path
+	 */
+	protected $path = '/index.php/apps/user_management';
+
+	protected $userTrXpath = ".//table[@id='userlist']/tbody/tr";
+
+	protected $quotaSelectXpath = ".//select[@class='quota-user']";
+
+	protected $quotaOptionXpath = "//option[contains(text(), '%s')]";
+
+	protected $manualQuotaInputXpath = "//input[contains(@data-original-title,'Please enter storage quota')]";
+	protected $settingsBtnXpath = ".//*[@id='app-settings-header']/button";
+	protected $settingContentId = "app-settings-content";
+	protected $labelMailOnUserCreateXpath = ".//label[@for='CheckboxMailOnUserCreate']";
+	protected $settingByTextXpath = ".//*[@id='userlistoptions']//label[normalize-space()='%s']";
+	protected $newUserUsernameFieldId = "newusername";
+	protected $newUserPasswordFieldId = "newuserpassword";
+	protected $newUserEmailFieldId = "newemail";
+	protected $createUserBtnXpath = ".//*[@id='newuser']/input[@type='submit']";
+	protected $newUserGroupsDropDownXpath = ".//*[@id='newuser']//div[@class='groupsListContainer multiselect button']";
+	protected $newUserGroupsDropDownListTag = "li";
+	protected $newUserGroupsSelectedClass = "selected";
+	protected $newUserGroupsListXpath = ".//*[@id='newuser']//ul[@class='multiselectoptions down']";
+	protected $newUserGroupXpath = ".//*[@id='newuser']//ul[@class='multiselectoptions down']//label[@title='%s']/..";
+	protected $newUserAddGroupBtnXpath = ".//*[@id='newuser']//ul[@class='multiselectoptions down']//li[@title='add group']";
+	protected $createGroupWithNewUserInputXpath = ".//*[@id='newuser']//ul[@class='multiselectoptions down']//input[@type='text']";
+	protected $groupListId = "usergrouplist";
+	/**
+	 * @param string $username
+	 *
+	 * @return NodeElement for the requested user in the table
+	 * @throws \Exception
+	 */
+	public function findUserInTable($username) {
+		$userTrs = $this->findAll('xpath', $this->userTrXpath);
+
+		foreach ($userTrs as $userTr) {
+			$user = $userTr->find("css", ".name");
+			if ($this->getTrimmedText($user) === $username) {
+				return $userTr;
+			}
+		}
+		throw new \Exception("Could not find user '$username'");
+	}
+
+	/**
+	 * @param string $username
+	 *
+	 * @throws ElementNotFoundException
+	 * @return string text describing the quota
+	 */
+	public function getQuotaOfUser($username) {
+		$userTr = $this->findUserInTable($username);
+		$selectField = $userTr->find('xpath', $this->quotaSelectXpath);
+
+		if (is_null($selectField)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->quotaSelectXpath " .
+				"could not find quota select element"
+			);
+		}
+
+		$xpathLocator = "//option[@value='" . $selectField->getValue() . "']";
+		$selectField = $selectField->find('xpath', $xpathLocator);
+
+		if (is_null($selectField)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $xpathLocator " .
+				"could not find quota element"
+			);
+		}
+
+		return $this->getTrimmedText($selectField);
+	}
+
+	/**
+	 * Open the settings menu
+	 *
+	 * @throws ElementNotFoundException
+	 * @return void
+	 */
+	public function openSettingsMenu() {
+		$settingsBtn = $this->find("xpath", $this->settingsBtnXpath);
+		if (is_null($settingsBtn)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->settingsBtnXpath " .
+				"could not find settings button"
+			);
+		}
+		$settingsBtn->click();
+	}
+
+	/**
+	 * sets a setting in the settings menu
+	 *
+	 * @param string $setting the human readable setting string
+	 * @param boolean $value
+	 *
+	 * @throws ElementNotFoundException
+	 * @return void
+	 */
+	public function setSetting($setting, $value = true) {
+		$settingContent = $this->findById($this->settingContentId);
+		if (is_null($settingContent)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" id $this->settingContentId " .
+				"could not find setting content"
+			);
+		}
+
+		try {
+			$settingContentIsVisible = $settingContent->isVisible();
+		} catch (NoSuchElement $e) {
+			// Somehow on Edge this can throw NoSuchElement even though
+			// we just found the element.
+			// TODO: Edge - if it keeps happening then find out why.
+			error_log(
+				__METHOD__
+				. " NoSuchElement while doing settingContent->isVisible()"
+				. "\n-------------------------\n"
+				. $e->getMessage()
+				. "\n-------------------------\n"
+			);
+			$settingContentIsVisible = false;
+		}
+
+		if (!$settingContentIsVisible) {
+			$this->openSettingsMenu();
+		}
+
+		$xpathLocator = sprintf($this->settingByTextXpath, $setting);
+		$settingLabel = $this->find("xpath", $xpathLocator);
+		if (is_null($settingLabel)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $xpathLocator " .
+				"could not find setting '" . $setting . "'"
+			);
+		}
+		//the checkbox is not visible, but we need it to find the status
+		$checkBoxId = $settingLabel->getAttribute("for");
+		$checkBox = $this->findById($checkBoxId);
+		if (is_null($checkBox)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" could not find checkbox with the id '" . $checkBoxId . "'"
+			);
+		}
+		if ($checkBox->isChecked() !== $value) {
+			$settingLabel->click();
+		}
+	}
+
+	/**
+	 * creates a user and adds it to the required groups
+	 * if group does not exist it will be created
+	 *
+	 * @param Session $session
+	 * @param string $username
+	 * @param string $password
+	 * @param string $email
+	 * @param string[] $groups
+	 *
+	 * @throws ElementNotFoundException
+	 * @return void
+	 */
+	public function createUser(
+		Session $session, $username, $password, $email = null, $groups = null
+	) {
+		$this->fillField($this->newUserUsernameFieldId, $username);
+		$this->fillField($this->newUserPasswordFieldId, $password);
+		$this->setSetting("Send email to new user", !is_null($email));
+		if (!is_null($email)) {
+			$this->fillField($this->newUserEmailFieldId, $email);
+		}
+		$createUserBtn = $this->find("xpath", $this->createUserBtnXpath);
+		if (is_null($createUserBtn)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->createUserBtnXpath " .
+				"could not find create user button"
+			);
+		}
+		$newUserGroupsDropDown = $this->find(
+			"xpath", $this->newUserGroupsDropDownXpath
+		);
+		if (is_null($newUserGroupsDropDown)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->newUserGroupsDropDownXpath " .
+				"could not find groups dropdown for new user"
+			);
+		}
+		$newUserGroupsDropDown->click();
+		$groupDropDownList = $this->find("xpath", $this->newUserGroupsListXpath);
+		if (is_null($groupDropDownList)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->newUserGroupsListXpath " .
+				"could not find groups dropdown list"
+			);
+		}
+		$groupsInDropDown = $groupDropDownList->findAll(
+			"xpath", $this->newUserGroupsDropDownListTag
+		);
+
+		//uncheck all selected groups
+		foreach ($groupsInDropDown as $groupLi) {
+			if ($groupLi->getAttribute("class") === $this->newUserGroupsSelectedClass) {
+				$groupLi->click();
+			}
+		}
+
+		//now select all groups that we need to have
+		if (is_array($groups)) {
+			foreach ($groups as $group) {
+				$groupItem = $this->find(
+					"xpath", sprintf($this->newUserGroupXpath, $group)
+				);
+				if (!is_null($groupItem)) {
+					$groupItem->click();
+				} else {
+					$newUserAddGroupBtn = $this->find(
+						"xpath", $this->newUserAddGroupBtnXpath
+					);
+					if (is_null($newUserAddGroupBtn)) {
+						throw new ElementNotFoundException(
+							__METHOD__ .
+							" xpath $this->newUserAddGroupBtnXpath " .
+							"could not find add-group button while creating a new user"
+						);
+					}
+					$newUserAddGroupBtn->click();
+					$createUserInput = $this->find(
+						"xpath", $this->createGroupWithNewUserInputXpath
+					);
+					if (is_null($createUserInput)) {
+						throw new ElementNotFoundException(
+							__METHOD__ .
+							" xpath $this->createGroupWithNewUserInputXpath " .
+							"could not find add-group input while creating a new user"
+						);
+					}
+					try {
+						$createUserInput->setValue($group . "\n");
+					} catch (NoSuchElement $e) {
+						// this seems to be a bug in MinkSelenium2Driver.
+						// Actually all that we need does happen, so we just don't do anything
+					}
+				}
+			}
+		}
+
+		$createUserBtn->click();
+		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+
+	/**
+	 * @param string $username
+	 * @param string $quota text form of quota to be input
+	 * @param Session $session
+	 *
+	 * @throws ElementNotFoundException
+	 * @return void
+	 */
+	public function setQuotaOfUserTo($username, $quota, Session $session) {
+		$userTr = $this->findUserInTable($username);
+		$selectField = $userTr->find('xpath', $this->quotaSelectXpath);
+
+		if (is_null($selectField)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->quotaSelectXpath " .
+				"could not find quota select element"
+			);
+		}
+
+		$selectOption = $selectField->find(
+			'xpath', sprintf($this->quotaOptionXpath, $quota)
+		);
+		if (is_null($selectOption)) {
+			$xpathLocator = sprintf($this->quotaOptionXpath, "Other");
+			$selectOption = $selectField->find('xpath', $xpathLocator);
+
+			if (is_null($selectOption)) {
+				throw new ElementNotFoundException(
+					__METHOD__ .
+					" xpath $xpathLocator " .
+					"could not find quota option element"
+				);
+			}
+
+			$selectOption->click();
+			$manualQuotaInputElement = $this->find('xpath', $this->manualQuotaInputXpath);
+
+			if (is_null($manualQuotaInputElement)) {
+				throw new ElementNotFoundException(
+					__METHOD__ .
+					" xpath $this->manualQuotaInputXpath " .
+					"could not find manual quota input element"
+				);
+			}
+
+			$manualQuotaInputElement->setValue($quota);
+		} else {
+			$selectOption->click();
+		}
+		$this->waitForOutstandingAjaxCalls($session);
+	}
+
+	/**
+	 *
+	 * @throws ElementNotFoundException
+	 * @return GroupList
+	 */
+	private function getGroupListElement() {
+		$groupListElement = $this->findById($this->groupListId);
+		if (is_null($groupListElement)) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" id $this->groupListId " .
+				"could not find group list element"
+			);
+		}
+
+		/**
+		 *
+		 * @var GroupList $groupList
+		 */
+		$groupList = $this->getPage("UserPageElement\\GroupList");
+		$groupList->setElement($groupListElement);
+		return $groupList;
+	}
+
+	/**
+	 * returns all group names as an array
+	 *
+	 * @return string[]
+	 */
+	public function getAllGroups() {
+		$groupList = $this->getGroupListElement();
+		return $groupList->namesToArray();
+	}
+
+	/**
+	 *
+	 * @param string $name
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function deleteGroup($name, Session $session) {
+		$groupList = $this->getGroupListElement();
+		$groupList->deleteGroup($name);
+		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+
+	/** 
+	 * 
+	 * @param string $groupName
+	 * @param Session $session
+	 *
+	 * @return void
+	 */
+	public function addGroup($groupName, Session $session) {
+		$groupList = $this->getGroupListElement();
+		$groupList->addGroup($groupName);
+		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+}

--- a/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
+++ b/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
@@ -1,0 +1,50 @@
+@webUI @insulated @disablePreviews
+Feature: manage user quota
+	As an admin
+	I want to manage user quota
+	So that users can only take up a certain amount of storage space
+
+	Background:
+		Given these users have been created but not initialized:
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
+		And user admin has logged in using the webUI
+		And the administrator has browsed to the users page
+
+	Scenario Outline: change quota to a valid value
+		Given the administrator has set the quota of user "user1" to "<start_quota>" using the webUI
+		When the administrator changes the quota of user "user1" to "<wished_quota>" using the webUI
+		And the administrator reloads the users page
+		Then the quota of user "user1" should be set to "<expected_quota>" on the webUI
+
+		Examples:
+			|start_quota|wished_quota|expected_quota|
+			|Unlimited  |5 GB        |5 GB          |
+			|1 GB       |5 GB        |5 GB          |
+			|5 GB       |Unlimited   |Unlimited     |
+			|1 GB       |Unlimited   |Unlimited     |
+			|Unlimited  |5.5 GB      |5.5 GB        |
+			|Unlimited  |5B          |5 B           |
+			|Unlimited  |55kB        |55 KB         |
+			|Unlimited  |45Kb        |45 KB         |
+
+	@skipOnOcV10.0.3
+	Scenario: change quota to a valid value that do not work on 10.0.3
+		Given the administrator has set the quota of user "user1" to "Unlimited" using the webUI
+		When the administrator changes the quota of user "user1" to "0 Kb" using the webUI
+		And the administrator reloads the users page
+		Then the quota of user "user1" should be set to "0 B" on the webUI
+
+	Scenario Outline: change quota to an invalid value
+		When the administrator changes the quota of user "user1" to "<wished_quota>" using the webUI
+		Then a notification should be displayed on the webUI with the text 'Invalid quota value "<wished_quota>"'
+		And the quota of user "user1" should be set to "Default" on the webUI
+
+		Examples:
+			|wished_quota|
+			|stupidtext  |
+			|34,54GB     |
+			|30/40GB     |
+			|30/40       |
+			|3+56 B      |
+			|-1 B        |

--- a/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
@@ -1,0 +1,16 @@
+@webUI @insulated @disablePreviews
+Feature: Add group
+	As an admin
+	I would like to add a group
+	So that I can share documents with other users
+
+	Background:
+		Given user admin has logged in using the webUI
+		And the administrator has browsed to the users page
+
+	Scenario Outline: Add group
+		When the administrator adds group <groupname> using the webUI
+		Then the group name <groupname> should be listed on the webUI
+		Examples:
+			|groupname|
+			|"localuser" |

--- a/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
@@ -1,0 +1,113 @@
+@webUI @insulated @disablePreviews
+Feature: manage groups
+	As an admin
+	I want to manage groups
+	So that access to resources can be controlled more effectively
+
+	Background:
+		Given user admin has logged in using the webUI
+		And the administrator has browsed to the users page
+
+	@skipOnOcV10.0.3
+	Scenario: delete group called "0" and "false"
+		Given these groups have been created:
+			|groupname     |
+			|do-not-delete |
+			|0             |
+			|false         |
+			|do-not-delete2|
+		And the administrator has browsed to the users page
+		When the administrator deletes these groups using the webUI:
+			|groupname|
+			|0        |
+			|false    |
+		And the administrator reloads the users page
+		Then these groups should be listed on the webUI:
+			|groupname     |
+			|do-not-delete |
+			|do-not-delete2|
+		But these groups should not be listed on the webUI:
+			|groupname|
+			|0        |
+			|false    |
+		And these groups should exist:
+			|groupname     |
+			|do-not-delete |
+			|do-not-delete2|
+		But these groups should not exist:
+			|groupname|
+			|0        |
+			|false    |
+
+	@skipOnOcV10.0.3 @skipOnOcV10.0.4 @skipOnOcV10.0.5
+	Scenario: delete groups with special characters that appear in URLs
+		Given these groups have been created:
+			|groupname     |
+			|do-not-delete |
+			|a/slash       |
+			|per%cent      |
+			|hash#char     |
+			|q?mark        |
+			|do-not-delete2|
+		And the administrator has browsed to the users page
+		When the administrator deletes these groups using the webUI:
+			|groupname     |
+			|a/slash       |
+			|per%cent      |
+			|hash#char     |
+			|q?mark        |
+		And the administrator reloads the users page
+		Then these groups should be listed on the webUI:
+			|groupname     |
+			|do-not-delete |
+			|do-not-delete2|
+		But these groups should not be listed on the webUI:
+			|groupname     |
+			|a/slash       |
+			|per%cent      |
+			|hash#char     |
+			|q?mark        |
+		And these groups should exist:
+			|groupname     |
+			|do-not-delete |
+			|do-not-delete2|
+		But these groups should not exist:
+			|groupname     |
+			|a/slash       |
+			|per%cent      |
+			|hash#char     |
+			|q?mark        |
+
+	Scenario: delete groups with problematic names
+		Given these groups have been created:
+			|groupname     |
+			|do-not-delete |
+			|grp1          |
+			|quotes'       |
+			|quotes"       |
+			|do-not-delete2|
+		And the administrator has browsed to the users page
+		When the administrator deletes these groups using the webUI:
+			|groupname|
+			|grp1     |
+			|quotes'  |
+			|quotes"  |
+		And the administrator reloads the users page
+		Then these groups should be listed on the webUI:
+			|groupname     |
+			|do-not-delete |
+			|do-not-delete2|
+		But these groups should not be listed on the webUI:
+			|groupname|
+			|grp1     |
+			|quotes'  |
+			|quotes"  |
+		And these groups should exist:
+			|groupname     |
+			|do-not-delete |
+			|do-not-delete2|
+		But these groups should not exist:
+			|groupname|
+			|grp1     |
+			|quotes'  |
+			|quotes"  |

--- a/tests/acceptance/features/webUIManageUsersGroups/manageUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/manageUsers.feature
@@ -1,0 +1,49 @@
+@webUI @insulated @disablePreviews
+Feature: manage users
+  As an admin
+  I want to manage users
+  So that unauthorised access is impossible
+
+  Background:
+    Given user admin has logged in using the webUI
+    And the administrator has browsed to the users page
+
+  Scenario: use the webUI to create a simple user
+    When the administrator creates a user with the name "guiusr1" and the password "pwd" using the webUI
+    And the administrator logs out of the webUI
+    And the user logs in with username "guiusr1" and password "pwd" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+
+  Scenario: use the webUI to create a user with special valid characters
+    When the administrator creates a user with the name "@-_.'" and the password "pwd" using the webUI
+    And the administrator logs out of the webUI
+    And the user logs in with username "@-_.'" and password "pwd" using the webUI
+    Then the user should be redirected to a webUI page with the title "Files - ownCloud"
+
+  Scenario Outline: use the webUI to create a user with special invalid characters
+    When the administrator attempts to create a user with the name <user> and the password <pwd> using the webUI
+    Then notifications should be displayed on the webUI with the text
+      |Error creating user: Only the following characters are allowed in a username: "a-z", "A-Z", "0-9", and "_.@-'"|
+    And the user should be redirected to a webUI page with the title "Users - ownCloud"
+    Examples:
+      | user | pwd |
+      |"a#%"|"pwd1"|
+      |"a+^"|"pwd2"|
+      |"a)~"|"pwd2"|
+      |"a(="|"pwd2"|
+      |"a`*^"|"pwd2"|
+
+  Scenario: use the webUI to create a user with empty password
+    When the administrator attempts to create a user with the name "bijay" and the password "" using the webUI
+    Then notifications should be displayed on the webUI with the text
+      |Error creating user: A valid password must be provided|
+    And the user should be redirected to a webUI page with the title "Users - ownCloud"
+
+  Scenario Outline: use the webUI to create a user with less than 3 characters
+    When the administrator attempts to create a user with the name <user> and the password <pwd> using the webUI
+    Then notifications should be displayed on the webUI with the text
+      |Error creating user: The username must be at least 3 characters long|
+    Examples:
+      |user|  pwd |
+      |"a" | "abc"|
+      |"a1"|"abcd"|


### PR DESCRIPTION
Add tests/acceptance folder, containing the ``webUIManageQuota`` and ``webUIManageUsersGroups`` test suites that used to be in ``core`` ``master``.

Put together the various infrastructure needed - ``behat.yml`` and so on.

Note: ``login.feature`` was in ``webUIManageUsersGroups`` - it is being left in ``core`` because it is not a UI user management feature, it belongs in ``core``. See https://github.com/owncloud/core/pull/30874