### PR TITLE
notify of failures when pushes occur on master/release branch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@ workspace:
   base: /var/www/owncloud
   path: apps/user_management
 
-branches: [master]
+branches: [ master, release* ]
 
 pipeline:
   install-server:
@@ -108,6 +108,15 @@ pipeline:
       matrix:
         TEST_SUITE: phpunit
         PHP_VERSION: 7.1
+
+  notify:
+    image: plugins/slack:1
+    pull: true
+    secrets: [ slack_webhook ]
+    channel: builds
+    when:
+      status: [ failure, changed ]
+      event: [ push, tag ]
 
 services:
   server:


### PR DESCRIPTION
## Motivation

To check if the build fails during nightly runs - we need to check the build status on the latest push.

Additionally it is good to know, if any push on the release branches results in a failure