### PR TITLE
do not urlencode group id

### DIFF
--- a/js/groups.js
+++ b/js/groups.js
@@ -295,7 +295,7 @@ GroupList = {
 	},
 
 	getElementGID: function (element) {
-		return encodeURIComponent(($(element).closest('li').attr('data-gid') || '')).toString();
+		return ($(element).closest('li').attr('data-gid') || '');
 	},
 	getEveryoneCount: function () {
 		$.ajax({

--- a/js/groups.js
+++ b/js/groups.js
@@ -279,7 +279,7 @@ GroupList = {
 		//when to mark user for delete
 		$userGroupList.on('click', '.delete', function () {
 			// Call function for handling delete/undo
-			GroupDeleteHandler.mark(GroupList.getElementGID(this));
+			GroupDeleteHandler.mark(encodeURIComponent(GroupList.getElementGID(this)).toString());
 		});
 
 		//delete a marked user when leaving the page

--- a/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/manageGroups.feature
@@ -83,31 +83,35 @@ Feature: manage groups
 			|groupname     |
 			|do-not-delete |
 			|grp1          |
+			|space group   |
 			|quotes'       |
 			|quotes"       |
 			|do-not-delete2|
 		And the administrator has browsed to the users page
 		When the administrator deletes these groups using the webUI:
-			|groupname|
-			|grp1     |
-			|quotes'  |
-			|quotes"  |
+			| groupname   |
+			| grp1        |
+			| space group |
+			| quotes'     |
+			| quotes"     |
 		And the administrator reloads the users page
 		Then these groups should be listed on the webUI:
 			|groupname     |
 			|do-not-delete |
 			|do-not-delete2|
 		But these groups should not be listed on the webUI:
-			|groupname|
-			|grp1     |
-			|quotes'  |
-			|quotes"  |
+			| groupname   |
+			| grp1        |
+			| space group |
+			| quotes'     |
+			| quotes"     |
 		And these groups should exist:
 			|groupname     |
 			|do-not-delete |
 			|do-not-delete2|
 		But these groups should not exist:
-			|groupname|
-			|grp1     |
-			|quotes'  |
-			|quotes"  |
+			| groupname   |
+			| grp1        |
+			| space group |
+			| quotes'     |
+			| quotes"     |


### PR DESCRIPTION
fixes https://github.com/owncloud/user_management/issues/19

Text added by phil-davis:
Also see core issue https://github.com/owncloud/core/issues/31279 - groups with ``/`` or ``%`` in the name do not list the members

These problems are here in the ``user_management`` app, and also in ``core`` ``stable10`` (which still has this user management code bundled in core)