### PR TITLE
Remove mailhogUrl from behat.yml - was removed in core

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -21,7 +21,6 @@ default:
             adminUsername: admin
             adminPassword: admin
             regularUserPassword: 123456
-            mailhogUrl: http://127.0.0.1:8025/api/v2/messages
             ocPath: ../../../../
         - WebUIGeneralContext:
         - WebUILoginContext:


### PR DESCRIPTION
1) Remove mailhogUrl from behat.yml - was removed in core

and likely also needs changes to fix testing on the webUI with a group called "a/slash"