### PR TITLE
Fix missing asterisk in the php-doc

### DIFF
--- a/lib/Controller/UsersController.php
+++ b/lib/Controller/UsersController.php
@@ -865,58 +865,58 @@ class UsersController extends Controller {
 			}
 		}
 		return new RedirectResponse($this->urlGenerator->linkToRoute('settings.SettingsPage.getPersonal', ['changestatus' => 'success', 'user' => $userId]));
-  }
-  
-  /*
+	}
+
+	/**
 	 * @NoAdminRequired
 	 *
 	 * @param string $id
 	 * @return DataResponse
 	 */
 	public function setEnabled($id, $enabled) {
-                $userId = $this->userSession->getUser()->getUID();
-                $user = $this->userManager->get($id);
+		$userId = $this->userSession->getUser()->getUID();
+		$user = $this->userManager->get($id);
 
-                if($userId === $id ||
-                        (!$this->isAdmin &&
-                        !$this->groupManager->getSubAdmin()->isUserAccessible($this->userSession->getUser(), $user))) {
-                        return new DataResponse(
-                                array(
-                                        'status' => 'error',
-                                        'data' => array(
-                                                'message' => (string)$this->l10n->t('Forbidden')
-                                        )
-                                ),
-                                Http::STATUS_FORBIDDEN
-                        );
-                }
+		if($userId === $id ||
+			(!$this->isAdmin &&
+				!$this->groupManager->getSubAdmin()->isUserAccessible($this->userSession->getUser(), $user))) {
+			return new DataResponse(
+				array(
+					'status' => 'error',
+					'data' => array(
+						'message' => (string)$this->l10n->t('Forbidden')
+					)
+				),
+				Http::STATUS_FORBIDDEN
+			);
+		}
 
 
-                if(!$user){
-                        return new DataResponse(
-                                array(
-                                        'status' => 'error',
-                                        'data' => array(
-                                                'message' => (string)$this->l10n->t('Invalid user')
-                                        )
-                                ),
-                                Http::STATUS_UNPROCESSABLE_ENTITY
-                        );
-                }
+		if(!$user) {
+			return new DataResponse(
+				array(
+					'status' => 'error',
+					'data' => array(
+						'message' => (string)$this->l10n->t('Invalid user')
+					)
+				),
+				Http::STATUS_UNPROCESSABLE_ENTITY
+			);
+		}
 
 
 		$value = filter_var($enabled, FILTER_VALIDATE_BOOLEAN);
 		if(!isset($value) || is_null($value))
 		{
-                        return new DataResponse(
-                                array(
-                                        'status' => 'error',
-                                        'data' => array(
-                                                'message' => (string)$this->l10n->t('Unable to enable/disable user.')
-                                        )
-                                ),
-                                Http::STATUS_FORBIDDEN
-                        );
+			return new DataResponse(
+				array(
+					'status' => 'error',
+					'data' => array(
+						'message' => (string)$this->l10n->t('Unable to enable/disable user.')
+					)
+				),
+				Http::STATUS_FORBIDDEN
+			);
 		}
 
 		$user->setEnabled($value);


### PR DESCRIPTION
Fix the missing asterisk in the php-doc.
Without the asterisk it might affect the
annotation parseing.

Signed-off-by: Sujith H <sharidasan@owncloud.com>