### PR TITLE
Checkboxes to hide quota and password

### DIFF
--- a/ajax/togglegroups.php
+++ b/ajax/togglegroups.php
@@ -79,5 +79,8 @@ if (\OC::$server->getGroupManager()->inGroup($username, $group)) {
 	$targetGroupObject->addUser($targetUserObject);
 }
 
-// Return Success story
-OC_JSON::success(["data" => ["username" => $username, "action" => $action, "groupname" => $group]]);
+if(\OC::$server->getGroupManager()->isInGroup($username, $group)) {
+	OC_JSON::success(["data" => ["username" => $username, "action" => $action, "groupname" => $group]]);
+} else {
+	OC_JSON::error();
+}

--- a/ajax/togglegroups.php
+++ b/ajax/togglegroups.php
@@ -79,7 +79,7 @@ if (\OC::$server->getGroupManager()->inGroup($username, $group)) {
 	$targetGroupObject->addUser($targetUserObject);
 }
 
-if(\OC::$server->getGroupManager()->isInGroup($username, $group)) {
+if (\OC::$server->getGroupManager()->isInGroup($username, $group)) {
 	OC_JSON::success(["data" => ["username" => $username, "action" => $action, "groupname" => $group]]);
 } else {
 	OC_JSON::error();

--- a/css/style.css
+++ b/css/style.css
@@ -80,6 +80,8 @@ span.usersLastLoginTooltip { white-space: nowrap; }
 #userlist {
 	position: relative;
 }
+#userlist .password,
+#userlist .quota,
 #userlist .mailAddress,
 #userlist .enabled,
 #userlist .storageLocation,

--- a/js/users.js
+++ b/js/users.js
@@ -1058,6 +1058,34 @@ $(document).ready(function () {
 		}
 	});
 
+	if ($('#CheckboxQuota').is(':checked')) {
+		$("#userlist .quota").show();
+	}
+	// Option to display/hide the "User Backend" column
+	$('#CheckboxQuota').click(function() {
+		if ($('#CheckboxQuota').is(':checked')) {
+			$("#userlist .quota").show();
+			OC.AppConfig.setValue('core', 'umgmt_show_quota', 'true');
+		} else {
+			$("#userlist .quota").hide();
+			OC.AppConfig.setValue('core', 'umgmt_show_quota', 'false');
+		}
+	});
+
+	if ($('#CheckboxPassword').is(':checked')) {
+		$("#userlist .password").show();
+	}
+	// Option to display/hide the "User Backend" column
+	$('#CheckboxPassword').click(function() {
+		if ($('#CheckboxPassword').is(':checked')) {
+			$("#userlist .password").show();
+			OC.AppConfig.setValue('core', 'umgmt_show_password', 'true');
+		} else {
+			$("#userlist .password").hide();
+			OC.AppConfig.setValue('core', 'umgmt_show_password', 'false');
+		}
+	});
+
 	// calculate initial limit of users to load
 	var initialUserCountLimit = UserList.initialUsersToLoad,
 		containerHeight = $('#app-content').height();

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -142,7 +142,10 @@ class PageController extends Controller {
 			'show_last_login' => $this->config->getAppValue('core', 'umgmt_show_last_login', 'false'),
 			'show_email' => $this->config->getAppValue('core', 'umgmt_show_email', 'false'),
 			'show_backend' => $this->config->getAppValue('core', 'umgmt_show_backend', 'false'),
-			'set_password' => $this->config->getAppValue('core', 'umgmt_set_password', 'false')
+			'set_password' => $this->config->getAppValue('core', 'umgmt_set_password', 'false'),
+			'send_email' => $this->config->getAppValue('core', 'umgmt_send_email', 'false'),
+			'show_password' => $this->config->getAppValue('core', 'umgmt_show_password', 'true'),
+			'show_quota' => $this->config->getAppValue('core', 'umgmt_show_quota', 'true'),
 			];
 
 		return new TemplateResponse('user_management', 'main', $params, 'user');

--- a/templates/main.php
+++ b/templates/main.php
@@ -101,6 +101,20 @@ translation('settings');
 						<?php p($l->t('Show email address')) ?>
 					</label>
 				</p>
+				<p>
+					<input type="checkbox" name="Password" value="Password" id="CheckboxPassword"
+						   class="checkbox" <?php if ($_['show_password'] === 'true') print_unescaped('checked="checked"'); ?> />
+					<label for="CheckboxPassword">
+						<?php p($l->t('Show password field')) ?>
+					</label>
+				</p>
+				<p>
+					<input type="checkbox" name="Quota" value="Quota" id="CheckboxQuota"
+						   class="checkbox" <?php if ($_['show_quota'] === 'true') print_unescaped('checked="checked"'); ?> />
+					<label for="CheckboxQuota">
+						<?php p($l->t('Show quota field')) ?>
+					</label>
+				</p>
 			</div>
 		</div>
 	</div>

--- a/templates/main.php
+++ b/templates/main.php
@@ -103,14 +103,18 @@ translation('settings');
 				</p>
 				<p>
 					<input type="checkbox" name="Password" value="Password" id="CheckboxPassword"
-						   class="checkbox" <?php if ($_['show_password'] === 'true') print_unescaped('checked="checked"'); ?> />
+						   class="checkbox" <?php if ($_['show_password'] === 'true') {
+	print_unescaped('checked="checked"');
+} ?> />
 					<label for="CheckboxPassword">
 						<?php p($l->t('Show password field')) ?>
 					</label>
 				</p>
 				<p>
 					<input type="checkbox" name="Quota" value="Quota" id="CheckboxQuota"
-						   class="checkbox" <?php if ($_['show_quota'] === 'true') print_unescaped('checked="checked"'); ?> />
+						   class="checkbox" <?php if ($_['show_quota'] === 'true') {
+	print_unescaped('checked="checked"');
+} ?> />
 					<label for="CheckboxQuota">
 						<?php p($l->t('Show quota field')) ?>
 					</label>

--- a/templates/part.userlist.php
+++ b/templates/part.userlist.php
@@ -5,11 +5,11 @@
 			<th id="headerAvatar" scope="col"></th>
 		<?php endif; ?>
 			<th id="headerName" scope="col"><?php p($l->t('Username'))?></th>
-			<th id="headerDisplayName" scope="col"><?php p($l->t( 'Full Name' )); ?></th>
-			<th class="password"  id="headerPassword" scope="col"><?php p($l->t( 'Password' )); ?></th>
-			<th class="mailAddress" scope="col"><?php p($l->t( 'Email' )); ?></th>
-			<th id="headerGroups" scope="col"><?php p($l->t( 'Groups' )); ?></th>
-		<?php if(\is_array($_['subadmins']) || $_['subadmins']): ?>
+			<th id="headerDisplayName" scope="col"><?php p($l->t('Full Name')); ?></th>
+			<th class="password"  id="headerPassword" scope="col"><?php p($l->t('Password')); ?></th>
+			<th class="mailAddress" scope="col"><?php p($l->t('Email')); ?></th>
+			<th id="headerGroups" scope="col"><?php p($l->t('Groups')); ?></th>
+		<?php if (\is_array($_['subadmins']) || $_['subadmins']): ?>
 			<th id="headerSubAdmins" scope="col"><?php p($l->t('Group Admin for')); ?></th>
 		<?php endif;?>
 			<th class="enabled" scope="col"><?php p($l->t('Enabled')); ?></th>

--- a/templates/part.userlist.php
+++ b/templates/part.userlist.php
@@ -5,15 +5,15 @@
 			<th id="headerAvatar" scope="col"></th>
 		<?php endif; ?>
 			<th id="headerName" scope="col"><?php p($l->t('Username'))?></th>
-			<th id="headerDisplayName" scope="col"><?php p($l->t('Full Name')); ?></th>
-			<th id="headerPassword" scope="col"><?php p($l->t('Password')); ?></th>
-			<th class="mailAddress" scope="col"><?php p($l->t('Email')); ?></th>
-			<th id="headerGroups" scope="col"><?php p($l->t('Groups')); ?></th>
-		<?php if (\is_array($_['subadmins']) || $_['subadmins']): ?>
+			<th id="headerDisplayName" scope="col"><?php p($l->t( 'Full Name' )); ?></th>
+			<th class="password"  id="headerPassword" scope="col"><?php p($l->t( 'Password' )); ?></th>
+			<th class="mailAddress" scope="col"><?php p($l->t( 'Email' )); ?></th>
+			<th id="headerGroups" scope="col"><?php p($l->t( 'Groups' )); ?></th>
+		<?php if(\is_array($_['subadmins']) || $_['subadmins']): ?>
 			<th id="headerSubAdmins" scope="col"><?php p($l->t('Group Admin for')); ?></th>
 		<?php endif;?>
 			<th class="enabled" scope="col"><?php p($l->t('Enabled')); ?></th>
-			<th id="headerQuota" scope="col"><?php p($l->t('Quota')); ?></th>
+			<th class="quota" id="headerQuota" scope="col"><?php p($l->t('Quota')); ?></th>
 			<th class="storageLocation" scope="col"><?php p($l->t('Storage Location')); ?></th>
 			<th class="userBackend" scope="col"><?php p($l->t('User Backend')); ?></th>
 			<th class="lastLogin" scope="col"><?php p($l->t('Last Login')); ?></th>

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -384,6 +384,62 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then /^the administrator should be able to see the quota of these users in the User Management page:$/
+	 *
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 */
+	public function theAdministratorShouldBeAbleToSeeQuotaOfTheseUsers(TableNode $table) {
+		foreach ($table as $row) {
+			$userQuota = $this->usersPage->getQuotaOfUser($row['username']);
+			PHPUnit_Framework_Assert::assertEquals($row['quota'], $userQuota);
+		}
+	}
+
+	/**
+	 * @Then /^the administrator should not be able to see the quota of these users in the User Management page:$/
+	 *
+	 * @param TableNode $table
+	 *
+	 * @return void
+	 */
+	public function theAdministratorShouldNotBeAbleToSeeQuotaOfTheseUsers(TableNode $table) {
+		foreach ($table as $row) {
+			$userQuota = $this->usersPage->getQuotaOfUser($row['username']);
+			PHPUnit_Framework_Assert::assertEquals('', $userQuota);
+		}
+	}
+
+	/**
+	 * @Then /^the administrator should be able to see the password of these users in the User Management page:$/
+	 *
+	 * @param TableNode $table table of usernames column with a heading | username |
+	 *
+	 * @return void
+	 */
+	public function theAdministratorShouldBeAbleToSeePasswordColumnOfTheseUsers(TableNode $table) {
+		foreach ($table as $row) {
+			$visible = $this->usersPage->isPasswordColumnOfUserVisible($row['username']);
+			PHPUnit_Framework_Assert::assertEquals(true, $visible);
+		}
+	}
+
+	/**
+	 * @Then /^the administrator should not be able to see the password of these users in the User Management page:$/
+	 *
+	 * @param TableNode $table table of usernames column with a heading | username |
+	 *
+	 * @return void
+	 */
+	public function theAdministratorShouldNotbeAbleToSeePasswordColumnOfTheseUsers(TableNode $table) {
+		foreach ($table as $row) {
+			$visible = $this->usersPage->isPasswordColumnOfUserVisible($row['username']);
+			PHPUnit_Framework_Assert::assertEquals(false, $visible);
+		}
+	}
+
+	/**
 	 * @Then /^the administrator should be able to see the storage location of these users in the User Management page:$/
 	 *
 	 * @param TableNode $table table of usernames and storage locations with a heading | username | and | storage location |

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -392,8 +392,8 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 */
 	public function theAdministratorShouldBeAbleToSeeQuotaOfTheseUsers(TableNode $table) {
 		foreach ($table as $row) {
-			$userQuota = $this->usersPage->getQuotaOfUser($row['username']);
-			PHPUnit_Framework_Assert::assertEquals($row['quota'], $userQuota);
+			$visible = $this->usersPage->isQuotaColumnOfUserVisible($row['username']);
+			PHPUnit_Framework_Assert::assertEquals(true, $visible);
 		}
 	}
 
@@ -406,8 +406,8 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 */
 	public function theAdministratorShouldNotBeAbleToSeeQuotaOfTheseUsers(TableNode $table) {
 		foreach ($table as $row) {
-			$userQuota = $this->usersPage->getQuotaOfUser($row['username']);
-			PHPUnit_Framework_Assert::assertEquals('', $userQuota);
+			$visible = $this->usersPage->isQuotaColumnOfUserVisible($row['username']);
+			PHPUnit_Framework_Assert::assertEquals(false, $visible);
 		}
 	}
 

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -48,6 +48,7 @@ class UsersPage extends OwncloudPage {
 	protected $quotaOptionXpath = "//option[contains(text(), '%s')]";
 
 	protected $emailColumnXpath = "//td[@class='mailAddress']";
+	protected $passwordColumnXpath = "//td[@class='password']";
 	protected $storageLocationColumnXpath = "//td[@class='storageLocation']";
 	protected $lastLoginXpath = "//td[@class='lastLogin']";
 	
@@ -174,6 +175,31 @@ class UsersPage extends OwncloudPage {
 		};
 
 		return $this->getTrimmedText($userEmail);
+	}
+
+	/**
+	 * @param string $username
+	 *
+	 * @return bool
+	 * @throws \Exception
+	 */
+	public function isPasswordColumnOfUserVisible($username) {
+		$userTr = $this->findUserInTable($username);
+		$userPassword = $userTr->find('xpath', $this->passwordColumnXpath);
+
+		if ($userPassword === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->passwordColumnXpath " .
+				"password column of user " . $username . " not found"
+			);
+		}
+
+		if (!$userPassword->isVisible()) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -49,6 +49,7 @@ class UsersPage extends OwncloudPage {
 
 	protected $emailColumnXpath = "//td[@class='mailAddress']";
 	protected $passwordColumnXpath = "//td[@class='password']";
+	protected $quotaColumnXpath = "//td[@class='quota']";
 	protected $storageLocationColumnXpath = "//td[@class='storageLocation']";
 	protected $lastLoginXpath = "//td[@class='lastLogin']";
 	
@@ -199,6 +200,30 @@ class UsersPage extends OwncloudPage {
 			return false;
 		}
 
+		return true;
+	}
+
+	/**
+	 * @param string $username
+	 *
+	 * @return bool
+	 * @throws \Exception
+	 */
+	public function isQuotaColumnOfUserVisible($username) {
+		$userTr = $this->findUserInTable($username);
+		$userQuota = $userTr->find('xpath', $this->quotaColumnXpath);
+
+		if ($userQuota === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->quotaColumnXpath " .
+				"quota column of user " . $username . " not found"
+			);
+		}
+
+		if (!$userQuota->isVisible()) {
+			return false;
+		}
 		return true;
 	}
 

--- a/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
+++ b/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
@@ -65,20 +65,15 @@ Feature: add users
       | username |   quota   |
       | user1    |   Default |
       | user2    |   Default |
-    And the administrator changes the quota of user "user1" to "Unlimited" using the webUI
-    And the administrator changes the quota of user "user2" to "5 GB" using the webUI
-    And the administrator logs out of the webUI
-    And user "user1" logs in using the webUI
-    And the user logs out of the webUI
-    And user "user2" logs in using the webUI
-    And the user logs out of the webUI
-    And user admin logs in using the webUI
-    And the administrator browses to the users page
+
+  Scenario: administrator should be able to see updated quota of user when enabled show quota field
+    Given the administrator has changed the quota of user "user1" to "Unlimited"
+    And the administrator has changed the quota of user "user2" to "5 GB"
+    When the administrator enables the setting "Show quota field" in the User Management page using the webUI
     Then the administrator should be able to see the quota of these users in the User Management page:
       | username |   quota     |
       | user1    |   Unlimited |
       | user2    |   5 GB      |
-
 
   Scenario: administrator should not be able to see quota of user
     When the administrator disables the setting "Show quota field" in the User Management page using the webUI
@@ -86,19 +81,3 @@ Feature: add users
       | username |
       | user1    |
       | user2    |
-    And the administrator enables the setting "Show quota field" in the User Management page using the webUI
-    And the administrator changes the quota of user "user1" to "Unlimited" using the webUI
-    And the administrator changes the quota of user "user2" to "5 GB" using the webUI
-    And the administrator disables the setting "Show quota field" in the User Management page using the webUI
-    And the administrator logs out of the webUI
-    And user "user1" logs in using the webUI
-    And the user logs out of the webUI
-    And user "user2" logs in using the webUI
-    And the user logs out of the webUI
-    And user admin logs in using the webUI
-    And the administrator browses to the users page
-    Then the administrator should not be able to see the quota of these users in the User Management page:
-      | username |
-      | user1    |
-      | user2    |
-

--- a/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
+++ b/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
@@ -44,3 +44,61 @@ Feature: add users
       | username | last login  |
       | user1    | seconds ago |
       | user2    | never       |
+
+  Scenario: administrator should be able to see password column of user
+    When the administrator enables the setting "Show password field" in the User Management page using the webUI
+    Then the administrator should be able to see the password of these users in the User Management page:
+      | username |
+      | user1    |
+      | user2    |
+
+  Scenario: administrator should not be able to see password column of user
+    When the administrator disables the setting "Show password field" in the User Management page using the webUI
+    Then the administrator should not be able to see the password of these users in the User Management page:
+      | username |
+      | user1    |
+      | user2    |
+
+  Scenario: administrator should be able to see quota of user
+    When the administrator enables the setting "Show quota field" in the User Management page using the webUI
+    Then the administrator should be able to see the quota of these users in the User Management page:
+      | username |   quota   |
+      | user1    |   Default |
+      | user2    |   Default |
+    And the administrator changes the quota of user "user1" to "Unlimited" using the webUI
+    And the administrator changes the quota of user "user2" to "5 GB" using the webUI
+    And the administrator logs out of the webUI
+    And user "user1" logs in using the webUI
+    And the user logs out of the webUI
+    And user "user2" logs in using the webUI
+    And the user logs out of the webUI
+    And user admin logs in using the webUI
+    And the administrator browses to the users page
+    Then the administrator should be able to see the quota of these users in the User Management page:
+      | username |   quota     |
+      | user1    |   Unlimited |
+      | user2    |   5 GB      |
+
+
+  Scenario: administrator should not be able to see quota of user
+    When the administrator disables the setting "Show quota field" in the User Management page using the webUI
+    Then the administrator should not be able to see the quota of these users in the User Management page:
+      | username |
+      | user1    |
+      | user2    |
+    And the administrator enables the setting "Show quota field" in the User Management page using the webUI
+    And the administrator changes the quota of user "user1" to "Unlimited" using the webUI
+    And the administrator changes the quota of user "user2" to "5 GB" using the webUI
+    And the administrator disables the setting "Show quota field" in the User Management page using the webUI
+    And the administrator logs out of the webUI
+    And user "user1" logs in using the webUI
+    And the user logs out of the webUI
+    And user "user2" logs in using the webUI
+    And the user logs out of the webUI
+    And user admin logs in using the webUI
+    And the administrator browses to the users page
+    Then the administrator should not be able to see the quota of these users in the User Management page:
+      | username |
+      | user1    |
+      | user2    |
+


### PR DESCRIPTION
Can now hide the password and quota fields using checkboxes and/or config options. Useful when configuring this screen for usage by group admins. 

<img width="254" alt="screen shot 2018-06-11 at 12 21 05" src="https://user-images.githubusercontent.com/660805/41228901-eff9d1d0-6d71-11e8-94ca-b030564367cf.png">

Defaults to true as this is the current behaviour.