### PR TITLE
UI test for disable user

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -247,7 +247,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the administrator deletes the user with the username :username using the webUI
+	 * @When the administrator deletes the user :username using the webUI
 	 *
 	 * @param string $username
 	 *

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -20,8 +20,6 @@
  *
  */
 
-require_once 'bootstrap.php';
-
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
@@ -29,11 +27,18 @@ use Behat\MinkExtension\Context\RawMinkContext;
 use Page\LoginPage;
 use Page\UsersPage;
 
+require_once 'bootstrap.php';
+
 /**
  * WebUI Users context.
  */
 class WebUIUsersContext extends RawMinkContext implements Context {
 	private $usersPage;
+
+	/**
+	 *
+	 * @var LoginPage
+	 */
 	private $loginPage;
 
 	/**
@@ -207,6 +212,38 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	public function theUserReloadsTheUsersPage() {
 		$this->getSession()->reload();
 		$this->usersPage->waitTillPageIsLoaded($this->getSession());
+	}
+
+	/**
+	 * @When the admin disables the user :username using the webUI
+	 *
+	 * @param string $username
+	 *
+	 * @return void
+	 */
+	public function theAdminDisablesTheUserUsingTheWebui($username) {
+		$this->usersPage->openSettingsMenu();
+		$this->usersPage->setSetting("Show enabled/disabled option");
+		$this->usersPage->disableUser($username);
+	}
+
+	/**
+	 * @When the disabled user :username tries to login using the password :password from the webUI
+	 *
+	 * @param string $username
+	 *
+	 * @param string $password
+	 *
+	 * @return void
+	 */
+	public function theDisabledUserTriesToLogin($username, $password) {
+		$this->webUIGeneralContext->theUserLogsOutOfTheWebUI();
+		/**
+		 *
+		 * @var DisabledUserPage $disabledPage
+		 */
+		$disabledPage = $this->loginPage->loginAs($username, $password, 'DisabledUserPage');
+		$disabledPage->waitTillPageIsLoaded($this->getSession());
 	}
 
 	/**

--- a/tests/acceptance/features/lib/DisabledUserPage.php
+++ b/tests/acceptance/features/lib/DisabledUserPage.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * ownCloud
+ *
+ * @author Paurakh Sharma Humagain <paurakh@jankaritech.com>
+ * @copyright Copyright (c) 2018 Paurakh Sharma Humagain paurakh@jankaritech.com
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License,
+ * as published by the Free Software Foundation;
+ * either version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Page;
+
+use Behat\Mink\Session;
+
+/**
+ * Disabled page.
+ */
+class DisabledUserPage extends OwncloudPage {
+
+	/**
+	 * @var string $path
+	 */
+	protected $path = '/index.php/login';
+	protected $userDisabledXpath = ".//li[@class='error']";
+
+	/**
+	 *
+	 * @param Session $session
+	 * @param int $timeout_msec
+	 *
+	 * @return void
+	 * @throws \Exception
+	 */
+	public function waitTillPageIsLoaded(
+		Session $session,
+		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+	) {
+		$currentTime = \microtime(true);
+		$end = $currentTime + ($timeout_msec / 1000);
+		while ($currentTime <= $end) {
+			if ($this->findAll("xpath", $this->userDisabledXpath)) {
+				break;
+			}
+			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			$currentTime = \microtime(true);
+		}
+
+		if ($currentTime > $end) {
+			throw new \Exception(
+				__METHOD__ . " timeout waiting for page to load"
+			);
+		}
+
+		$this->waitForOutstandingAjaxCalls($session);
+	}
+}

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -62,8 +62,9 @@ class UsersPage extends OwncloudPage {
 	protected $newUserAddGroupBtnXpath = ".//*[@id='newuser']//ul[@class='multiselectoptions down']//li[@title='add group']";
 	protected $createGroupWithNewUserInputXpath = ".//*[@id='newuser']//ul[@class='multiselectoptions down']//input[@type='text']";
 	protected $groupListId = "usergrouplist";
+	protected $disableUserCheckboxXpath = "//input[@type='checkbox']";
 	protected $deleteUserBtnXpath = ".//td[@class='remove']/a[@class='action delete']";
-	
+
 	/**
 	 * @param string $username
 	 *
@@ -409,6 +410,17 @@ class UsersPage extends OwncloudPage {
 		$groupList = $this->getGroupListElement();
 		$groupList->addGroup($groupName);
 		$this->waitForAjaxCallsToStartAndFinish($session);
+	}
+
+	/**
+	 *
+	 * @param string $username
+	 *
+	 * @return void
+	 */
+	public function disableUser($username) {
+		$userTr = $this->findUserInTable($username);
+		$userTr->find("xpath", $this->disableUserCheckboxXpath)->click();
 	}
 
 	/**

--- a/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
@@ -1,5 +1,5 @@
 @webUI @insulated @disablePreviews
-Feature: manage users
+Feature: add users
   As an admin
   I want to add users
   So that unauthorised access is impossible

--- a/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
@@ -13,7 +13,7 @@ Feature: delete users
 		And the administrator has browsed to the users page
 
 	Scenario: use the webUI to delete a simple user
-		When the administrator deletes the user with the username "user1" using the webUI
+		When the administrator deletes the user "user1" using the webUI
 		And the deleted user "user1" tries to login using the password "1234" using the webUI
 		Then the user should be redirected to a webUI page with the title "ownCloud"
 		When the user has browsed to the login page

--- a/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/deleteUsers.feature
@@ -1,8 +1,8 @@
 @webUI @insulated @disablePreviews
 Feature: delete users
-As an admin
-I want to delete users
-So that I can remove users
+	As an admin
+	I want to delete users
+	So that I can remove users
 
 	Background:
 		Given these users have been created but not initialized:
@@ -19,4 +19,3 @@ So that I can remove users
 		When the user has browsed to the login page
 		And the user logs in with username "user2" and password "1234" using the webUI
 		Then the user should be redirected to a webUI page with the title "Files - ownCloud"
-

--- a/tests/acceptance/features/webUIManageUsersGroups/disableUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/disableUsers.feature
@@ -1,0 +1,21 @@
+@webUI @insulated @disablePreviews
+Feature: disable users
+	As an admin
+	I want to disable users
+	So that I can remove access to unnecessary users
+
+	Background:
+		Given these users have been created but not initialized:
+			|username|password|displayname|email       |
+			|user1   |1234    |User One   |u1@oc.com.np|
+			|user2   |1234    |User Two   |u2@oc.com.np|
+		And user admin has logged in using the webUI
+		And the administrator has browsed to the users page
+
+	Scenario: disable a user
+		When the admin disables the user "user1" using the webUI
+		And the disabled user "user1" tries to login using the password "1234" from the webUI
+		Then the user should be redirected to a webUI page with the title "ownCloud"
+		When the user has browsed to the login page
+		And the user logs in with username "user2" and password "1234" using the webUI
+		Then the user should be redirected to a webUI page with the title "Files - ownCloud"

--- a/tests/acceptance/features/webUIManageUsersGroups/disableUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/disableUsers.feature
@@ -12,6 +12,7 @@ Feature: disable users
 		And user admin has logged in using the webUI
 		And the administrator has browsed to the users page
 
+	@skip @issue-24
 	Scenario: disable a user
 		When the admin disables the user "user1" using the webUI
 		And the disabled user "user1" tries to login using the password "1234" from the webUI


### PR DESCRIPTION
Forward port from core ``stable10``

Supersedes #25 

The 2nd commit just formats white space in ``deleteUsers.feature`` so it matches core ``stable10`` (this is a convenient place to also fixup this small difference)

The 3rd commit skips the test scenario, because it currently fails here in user_management - see issue #24 

4th commit - Make delete user acceptance test text consistent with disable user

5th commit - Fixup addUsers feature description