### PR TITLE
Use acceptance test run.sh for webUI tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -52,18 +52,17 @@ pipeline:
     environment:
       - BROWSER=chrome #chrome or firefox
       - SELENIUM_HOST=selenium
-      - SRV_HOST_NAME=server
-      - SRV_HOST_PORT=80
-      - REMOTE_FED_SRV_HOST_NAME=federated
-      - REMOTE_FED_SRV_HOST_PORT=80
-      - SKELETON_DIR=/var/www/owncloud/tests/acceptance/webUISkeleton
       - SELENIUM_PORT=4444
+      - TEST_SERVER_URL=http://server
+      - TEST_SERVER_FED_URL=http://federated
+      - SKELETON_DIR=/var/www/owncloud/tests/acceptance/webUISkeleton
       - PLATFORM=Linux
     commands:
       - cd /var/www/owncloud
       - chown www-data * -R
       - chmod 777 /var/www/owncloud/tests/acceptance/filesForUpload -R
-      - bash tests/travis/start_ui_tests.sh --remote --config /var/www/owncloud/apps/user_management/tests/acceptance/config/behat.yml
+      - cd tests/acceptance
+      - bash run.sh --remote --config /var/www/owncloud/apps/user_management/tests/acceptance/config/behat.yml
     when:
       matrix:
         TEST_SUITE: acceptance


### PR DESCRIPTION
After core https://github.com/owncloud/core/pull/31348 it is possible to run webUI acceptance tests from the common ``tests/acceptance/run.sh`` script, so do it.
