### PR TITLE
Remove unneeded SKELETON_DIR in .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -55,7 +55,6 @@ pipeline:
       - SELENIUM_PORT=4444
       - TEST_SERVER_URL=http://server
       - TEST_SERVER_FED_URL=http://federated
-      - SKELETON_DIR=/var/www/owncloud/tests/acceptance/webUISkeleton
       - PLATFORM=Linux
     commands:
       - cd /var/www/owncloud


### PR DESCRIPTION
SKELETON_DIR should have a correct default value in ``run.sh``, so it should not be needed here.

This will effectively implement the recent change of SKELETON_DIR location in core.