### PR TITLE
Make email field as default to create user

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -38,6 +38,9 @@ return [
 		['name' => 'Users#setEmailAddress', 'url' => '/admin/{id}/mailAddress', 'verb' => 'PUT'],
 		['name' => 'Users#setEnabled', 'url' => '/users/{id}/enabled', 'verb' => 'POST'],
 		['name' => 'Users#stats', 'url' => '/users/stats', 'verb' => 'GET'],
-		['name' => 'ChangePassword#changePassword', 'url' => '/users/changepassword', 'verb' => 'POST']
+		['name' => 'ChangePassword#changePassword', 'url' => '/users/changepassword', 'verb' => 'POST'],
+		['name' => 'Users#setPasswordForm', 'url' => '/setpassword/form/{token}/{userId}', 'verb' => 'GET'],
+		['name' => 'Users#resendToken', 'url' => '/resend/token/{userId}', 'verb' => 'POST'],
+		['name' => 'Users#setPassword', 'url' => '/setpassword/{token}/{userId}', 'verb' => 'POST'],
 	]
 ];

--- a/css/setpassword.css
+++ b/css/setpassword.css
@@ -1,0 +1,15 @@
+#reset-password p {
+	position: relative;
+}
+
+.text-center {
+	text-align: center;
+}
+
+#submit {
+	width: 100%;
+}
+
+#password {
+	width: 100%;
+}

--- a/js/setpassword.js
+++ b/js/setpassword.js
@@ -1,0 +1,52 @@
+(function () {
+	var SetPassword = {
+		init : function() {
+			$('#set-password #submit').click(this.onClickSetPassword);
+		},
+
+		onClickSetPassword : function(event){
+			event.preventDefault();
+			var passwordObj = $('#password');
+			if (passwordObj.val()){
+				$.post(
+					passwordObj.parents('form').attr('action'),
+					{password : passwordObj.val()}
+				).done(function (result) {
+					OCA.UserManagement.SetPassword._resetDone(result);
+				}).fail(function (result) {
+					OCA.UserManagement.SetPassword._onSetPasswordFail(result);
+				});
+			}
+		},
+
+		_onSetPasswordFail: function(result) {
+			var responseObj = JSON.parse(result.responseText);
+			var errorObject = $('#error-message');
+			var showErrorMessage = false;
+
+			var errorMessage;
+			errorMessage = responseObj.message;
+
+			if (errorMessage) {
+				errorObject.text(errorMessage);
+				errorObject.show();
+				$('#submit').prop('disabled', true);
+			}
+		},
+
+		_resetDone : function(result){
+			if (result && result.status === 'success') {
+				OC.redirect(OC.getRootPath());
+			}
+		}
+	};
+
+	if (!OCA.UserManagement) {
+		OCA.UserManagement = {};
+	}
+	OCA.UserManagement.SetPassword = SetPassword;
+})();
+
+$(document).ready(function () {
+	OCA.UserManagement.SetPassword.init();
+});

--- a/js/users.js
+++ b/js/users.js
@@ -722,6 +722,19 @@ $(document).ready(function () {
 	// TODO: move other init calls inside of initialize
 	UserList.initialize($('#userlist'));
 
+	OC.AppConfig.getValue('core', 'umgmt_set_password', 'false', function (data) {
+		var showPassword = $.parseJSON(data);
+		if (showPassword === true) {
+			$("#newuserpassword").show();
+			$("#newemail").hide();
+			$('#CheckBoxPasswordOnUserCreate').attr('checked', true);
+		} else {
+			$("#newemail").show();
+			$("#newuserpassword").hide();
+			$('#CheckBoxPasswordOnUserCreate').attr('checked', false);
+		}
+	});
+
 	$userListBody.on('click', '.password', function (event) {
 		event.stopPropagation();
 
@@ -894,20 +907,21 @@ $(document).ready(function () {
 			}));
 			return false;
 		}
-		if ($.trim(password) === '') {
-			OC.Notification.showTemporary(t('user_management', 'Error creating user: {message}', {
-				message: t('user_management', 'A valid password must be provided')
-			}));
-			return false;
-		}
-		if(!$('#CheckboxMailOnUserCreate').is(':checked')) {
-			email = '';
-		}
-		if ($('#CheckboxMailOnUserCreate').is(':checked') && $.trim(email) === '') {
-			OC.Notification.showTemporary( t('user_management', 'Error creating user: {message}', {
-				message: t('user_management', 'A valid email must be provided')
-			}));
-			return false;
+		if ($('#CheckBoxPasswordOnUserCreate').is(':checked')) {
+			if ($.trim(password) === '') {
+				OC.Notification.showTemporary(t('user_management', 'Error creating user: {message}', {
+					message: t('user_management', 'A valid password must be provided')
+				}));
+				return false;
+			}
+		} else {
+			if ($.trim(email) === '') {
+				OC.Notification.showTemporary( t('user_management', 'Error creating user: {message}', {
+					message: t('user_management', 'A valid email must be provided')
+				}));
+				return false;
+			}
+
 		}
 
 		var promise;
@@ -1025,17 +1039,19 @@ $(document).ready(function () {
 		}
 	});
 
-	if ($('#CheckboxMailOnUserCreate').is(':checked')) {
-		$("#newemail").show();
+	if ($('#CheckBoxPasswordOnUserCreate').is(':checked')) {
+		$("#newuserpassword").show();
 	}
-	// Option to display/hide the "E-Mail" input field
-	$('#CheckboxMailOnUserCreate').click(function() {
-		if ($('#CheckboxMailOnUserCreate').is(':checked')) {
-			$("#newemail").show();
-			OC.AppConfig.setValue('core', 'umgmt_send_email', 'true');
+	//Option to display/hide the "Password" input field
+	$('#CheckBoxPasswordOnUserCreate').click(function () {
+		if ($('#CheckBoxPasswordOnUserCreate').is(':checked')) {
+			OC.AppConfig.setValue('core', 'umgmt_set_password', 'true');
+			$('#newemail').hide();
+			$('#newuserpassword').show();
 		} else {
-			$("#newemail").hide();
-			OC.AppConfig.setValue('core', 'umgmt_send_email', 'false');
+			OC.AppConfig.setValue('core', 'umgmt_set_password', 'false');
+			$('#newemail').show();
+			$("#newuserpassword").hide();
 		}
 	});
 

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -142,7 +142,7 @@ class PageController extends Controller {
 			'show_last_login' => $this->config->getAppValue('core', 'umgmt_show_last_login', 'false'),
 			'show_email' => $this->config->getAppValue('core', 'umgmt_show_email', 'false'),
 			'show_backend' => $this->config->getAppValue('core', 'umgmt_show_backend', 'false'),
-			'send_email' => $this->config->getAppValue('core', 'umgmt_send_email', 'false')
+			'set_password' => $this->config->getAppValue('core', 'umgmt_set_password', 'false')
 			];
 
 		return new TemplateResponse('user_management', 'main', $params, 'user');

--- a/lib/Exception/InvalidUserTokenException.php
+++ b/lib/Exception/InvalidUserTokenException.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\UserManagement\Exception;
+
+class InvalidUserTokenException extends UserTokenException {
+	public function __construct($message = "", $code = 0) {
+		parent::__construct($message, $code, $this);
+	}
+}

--- a/lib/Exception/UserTokenException.php
+++ b/lib/Exception/UserTokenException.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\UserManagement\Exception;
+
+class UserTokenException extends \Exception {
+	public function __construct($message = "", $code, \Exception $previous = null) {
+		parent::__construct($message, $code, $previous);
+	}
+}

--- a/lib/Exception/UserTokenExpiredException.php
+++ b/lib/Exception/UserTokenExpiredException.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\UserManagement\Exception;
+
+class UserTokenExpiredException extends UserTokenException {
+	public function __construct($message = "", $code = 0) {
+		parent::__construct($message, $code, $this);
+	}
+}

--- a/lib/Exception/UserTokenMismatchException.php
+++ b/lib/Exception/UserTokenMismatchException.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\UserManagement\Exception;
+
+class UserTokenMismatchException extends UserTokenException {
+	public function __construct($message = "", $code = 0) {
+		parent::__construct($message, $code, $this);
+	}
+}

--- a/templates/main.php
+++ b/templates/main.php
@@ -84,12 +84,12 @@ translation('settings');
 					</label>
 				</p>
 				<p>
-					<input type="checkbox" name="MailOnUserCreate" value="MailOnUserCreate" id="CheckboxMailOnUserCreate"
-						class="checkbox" <?php if ($_['send_email'] === 'true') {
+					<input type="checkbox" name="AddPasswordOnUserCreate" value="AddPasswordOnUserCreate" id="CheckBoxPasswordOnUserCreate"
+						   class="checkbox" <?php if ($_['add_password'] === 'true') {
 	print_unescaped('checked="checked"');
 } ?> />
-					<label for="CheckboxMailOnUserCreate">
-						<?php p($l->t('Send email to new user')) ?>
+					<label for="CheckBoxPasswordOnUserCreate">
+						<?php p($l->t('Set password for new users')) ?>
 					</label>
 				</p>
 				<p>

--- a/templates/new_user/email-html.php
+++ b/templates/new_user/email-html.php
@@ -12,7 +12,7 @@
 					<td width="20px">&nbsp;</td>
 					<td style="font-weight:normal; font-size:0.8em; line-height:1.2em; font-family:verdana,'arial',sans;">
 						<?php
-						print_unescaped($l->t('Hey there,<br><br>just letting you know that you now have an %s account.<br><br>Your username: %s<br>Access it: <a href="%s">%s</a><br><br>', [$theme->getName(), $_['username'], $_['url'], $_['url']]));
+						print_unescaped($l->t('Hey there,<br><br>just letting you know that you now have an %s account.<br><br>Your username: %s<br>Please set the password by accessing it: <a href="%s">Here</a><br><br>', [$theme->getName(), $_['username'], $_['url']]));
 
 						// TRANSLATORS term at the end of a mail
 						p($l->t('Cheers!'));

--- a/templates/new_user/resendtokenbymail.php
+++ b/templates/new_user/resendtokenbymail.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+?>
+
+<form action="<?php print_unescaped($_['link']) ?>" id="resendtoken" method="post">
+	<fieldset>
+		<p>
+			<label><?php p($l->t('The activation link has expired. Click the button below to request a new one and complete the registration.')); ?></label>
+		</p>
+		<input type="submit" id="submit" value="<?php
+			p($l->t('Resend activation link'));
+		?>" />
+	</fieldset>
+</form>

--- a/templates/new_user/setpassword.php
+++ b/templates/new_user/setpassword.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+style('user_management', 'setpassword');
+script('user_management', 'setpassword');
+?>
+
+<label id="error-message" class="warning" style="display:none"></label>
+<form action="<?php print_unescaped($_['link']) ?>" id="set-password" method="post">
+	<fieldset>
+		<p>
+			<label for="password" class="infield"><?php p($l->t('New password')); ?></label>
+			<input type="password" name="password" id="password" value=""
+				   placeholder="<?php p($l->t('New Password')); ?>"
+				   autocomplete="off" autocapitalize="off" autocorrect="off"
+				   required autofocus />
+		</p>
+		<input type="submit" id="submit" value="<?php
+			p($l->t('Please set your password'));
+		?>" />
+	</fieldset>
+</form>

--- a/templates/new_user/tokensendnotify.php
+++ b/templates/new_user/tokensendnotify.php
@@ -1,0 +1,2 @@
+<?php
+p($l->t('Activation link was sent to an email address, if one was configured.'));

--- a/templates/part.createuser.php
+++ b/templates/part.createuser.php
@@ -4,10 +4,10 @@
 			placeholder="<?php p($l->t('Username'))?>"
 			autocomplete="off" autocapitalize="off" autocorrect="off" />
 		<input
-			type="password" id="newuserpassword"
+			type="password" id="newuserpassword" style="display:none"
 			placeholder="<?php p($l->t('Password'))?>"
 			autocomplete="off" autocapitalize="off" autocorrect="off" />
-		<input id="newemail" type="text" style="display:none"
+		<input id="newemail" type="text"
 			   placeholder="<?php p($l->t('E-Mail'))?>"
 			   autocomplete="off" autocapitalize="off" autocorrect="off" />
 		<div class="groups"><div class="groupsListContainer multiselect button" data-placeholder="<?php p($l->t('Groups'))?>"><span class="title groupsList"></span><span class="icon-triangle-s"></span></div></div>

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -220,9 +220,9 @@ class UsersPage extends OwncloudPage {
 	public function createUser(
 		Session $session, $username, $password, $email = null, $groups = null
 	) {
+		$this->setSetting("Set password for new users", $password !== null);
 		$this->fillField($this->newUserUsernameFieldId, $username);
 		$this->fillField($this->newUserPasswordFieldId, $password);
-		$this->setSetting("Send email to new user", $email !== null);
 		if ($email !== null) {
 			$this->fillField($this->newUserEmailFieldId, $email);
 		}


### PR DESCRIPTION
Make email field as default to create user.
Previously we had username, password. With
this change it becomes username, email. This
would help admins to create users with email
address.

Signed-off-by: Sujith H <sharidasan@owncloud.com>