### PR TITLE
Remove tests against core stable10

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -195,12 +195,6 @@ matrix:
      NEED_SERVER: true
      NEED_INSTALL_APP: true
 
-   - TEST_SUITE: phpunit
-     PHP_VERSION: 5.6
-     OC_VERSION: daily-stable10-qa
-     NEED_SERVER: true
-     NEED_INSTALL_APP: true
-
 #acceptance tests
    - TEST_SUITE: acceptance
      OC_VERSION: daily-master-qa
@@ -225,18 +219,3 @@ matrix:
      NEED_INSTALL_APP: true
      BEHAT_SUITE: webUISettingsMenu
      USE_EMAIL: true
-
-#
-#   - TEST_SUITE: acceptance
-#     OC_VERSION: daily-stable10-qa
-#     PHP_VERSION: 7.1
-#     NEED_SERVER: true
-#     NEED_INSTALL_APP: true
-#     BEHAT_SUITE: webUIManageQuota
-#
-#   - TEST_SUITE: acceptance
-#     OC_VERSION: daily-stable10-qa
-#     PHP_VERSION: 7.1
-#     NEED_SERVER: true
-#     NEED_INSTALL_APP: true
-#     BEHAT_SUITE: webUIManageUsersGroups


### PR DESCRIPTION
This app is split out in core master only. And with semver I doubt that the split will be pushed back into core stable10. IMO references here to core stable10 are misleading, and there is no need to try to test against it.