### PR TITLE
Clear email and password fields while toggling to create user

### DIFF
--- a/js/users.js
+++ b/js/users.js
@@ -1047,11 +1047,15 @@ $(document).ready(function () {
 		if ($('#CheckBoxPasswordOnUserCreate').is(':checked')) {
 			OC.AppConfig.setValue('core', 'umgmt_set_password', 'true');
 			$('#newemail').hide();
+			//Clear the value after hide
+			$('#newemail').val('');
 			$('#newuserpassword').show();
 		} else {
 			OC.AppConfig.setValue('core', 'umgmt_set_password', 'false');
 			$('#newemail').show();
-			$("#newuserpassword").hide();
+			$('#newuserpassword').hide();
+			//Clear the value after hide
+			$('#newuserpassword').val('');
 		}
 	});
 


### PR DESCRIPTION
Clear email and password fields while toggling
to create user. When using password field no
trail of email should be found. Similarly when
email field is used to create user the password
field should not have previous value.

Signed-off-by: Sujith H <sharidasan@owncloud.com>