### PR TITLE
Fix the token exception classes to avoid infinite loop with getPrevious

### DIFF
--- a/lib/Controller/UsersController.php
+++ b/lib/Controller/UsersController.php
@@ -527,7 +527,7 @@ class UsersController extends Controller {
 		try {
 			$this->checkPasswordSetToken($token, $userId);
 		} catch (UserTokenException $e) {
-			if ($e->getPrevious() instanceof UserTokenExpiredException) {
+			if ($e instanceof UserTokenExpiredException) {
 				return new TemplateResponse(
 					'user_management', 'new_user/resendtokenbymail',
 					[

--- a/lib/Exception/InvalidUserTokenException.php
+++ b/lib/Exception/InvalidUserTokenException.php
@@ -22,7 +22,7 @@
 namespace OCA\UserManagement\Exception;
 
 class InvalidUserTokenException extends UserTokenException {
-	public function __construct($message = "", $code = 0) {
-		parent::__construct($message, $code, $this);
+	public function __construct($message = "", $code = 0, \Exception $previous = null) {
+		parent::__construct($message, $code, $previous);
 	}
 }

--- a/lib/Exception/UserTokenExpiredException.php
+++ b/lib/Exception/UserTokenExpiredException.php
@@ -22,7 +22,7 @@
 namespace OCA\UserManagement\Exception;
 
 class UserTokenExpiredException extends UserTokenException {
-	public function __construct($message = "", $code = 0) {
-		parent::__construct($message, $code, $this);
+	public function __construct($message = "", $code = 0, \Exception $previous = null) {
+		parent::__construct($message, $code, $previous);
 	}
 }

--- a/lib/Exception/UserTokenMismatchException.php
+++ b/lib/Exception/UserTokenMismatchException.php
@@ -22,7 +22,8 @@
 namespace OCA\UserManagement\Exception;
 
 class UserTokenMismatchException extends UserTokenException {
-	public function __construct($message = "", $code = 0) {
-		parent::__construct($message, $code, $this);
+	public function __construct($message = "", $code = 0, \Exception $previous = null) {
+		$this->previousException = $this;
+		parent::__construct($message, $code, $previous);
 	}
 }


### PR DESCRIPTION
Fix the users token exception class to avoid infinite
loop when getPrevious method is called.

Signed-off-by: Sujith H <sharidasan@owncloud.com>