### PR TITLE
Fix the from address in the email when password reset

### DIFF
--- a/lib/Controller/UsersController.php
+++ b/lib/Controller/UsersController.php
@@ -717,7 +717,7 @@ class UsersController extends Controller {
 			$message->setTo([$email => $userId]);
 			$message->setSubject($this->l10n->t('%s password changed successfully', [$this->defaults->getName()]));
 			$message->setPlainBody($msg);
-			$message->setFrom([$email => $this->defaults->getName()]);
+			$message->setFrom([$this->fromMailAddress => $this->defaults->getName()]);
 			$this->mailer->send($message);
 		}
 	}

--- a/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
@@ -138,7 +138,6 @@ Feature: add users
     And the user logs in with username "guiusr1" and password "%regular%" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
-  @skip @issue-90
   Scenario: check if the sender email address is valid
     When the administrator creates a user with the name "user1" and the email "guiusr1@owncloud" without a password using the webUI
     And the administrator logs out of the webUI

--- a/tests/unit/UsersControllerTest.php
+++ b/tests/unit/UsersControllerTest.php
@@ -2069,6 +2069,7 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testSetPassword() {
+		$controller = $this->createController();
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())
 			->method('setPassword')
@@ -2092,6 +2093,10 @@ class UsersControllerTest extends TestCase {
 			->method('getAppValue')
 			->willReturn(43200);
 
+		$fromMailAddress = $this->invokePrivate($controller, 'fromMailAddress', []);
+		$this->defaults->method('getName')
+			->willReturn('ownCloud');
+
 		$message = $this->createMock(Message::class);
 		$message->expects($this->once())
 			->method('setTo')
@@ -2101,10 +2106,8 @@ class UsersControllerTest extends TestCase {
 			->willReturn($message);
 		$message->expects($this->once())
 			->method('setFrom')
+			->with([$fromMailAddress => 'ownCloud'])
 			->willReturn($message);
-
-		$this->defaults->method('getName')
-			->willReturn('ownCloud');
 
 		$this->mailer->expects($this->once())
 			->method('createMessage')
@@ -2114,8 +2117,10 @@ class UsersControllerTest extends TestCase {
 			->with($message)
 			->willReturn([]);
 
-		$result = $this->createController()->setPassword('fooBaZ1', 'foo', '123');
+		$result = $controller->setPassword('fooBaZ1', 'foo', '123');
 		$this->assertEquals(new Http\JSONResponse(['status' => 'success']), $result);
+		$this->assertNotEquals($fromMailAddress, 'foo@bar.com');
+		$this->assertEquals($fromMailAddress, 'no-reply@localhost');
 	}
 
 	/**


### PR DESCRIPTION
Use the global email address in the
from address when email is sent during
successful password set, by the user.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

Issue #90 