### PR TITLE
Add tests to check from address on passwordSetSuccess

### DIFF
--- a/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
@@ -137,3 +137,15 @@ Feature: add users
     And the user sets the password to "%regular%" using the webUI
     And the user logs in with username "guiusr1" and password "%regular%" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
+
+  @skip @issue-90
+  Scenario: check if the sender email address is valid
+    When the administrator creates a user with the name "user1" and the email "guiusr1@owncloud" without a password using the webUI
+    And the administrator logs out of the webUI
+    And the user follows the password set link received by "guiusr1@owncloud" using the webUI
+    And the user sets the password to "%regular%" using the webUI
+    Then the email address "guiusr1@owncloud" should have received an email with the body containing
+      """
+      Password changed successfully
+      """
+    And the reset email to "guiusr1@owncloud" should be from "owncloud@foobar.com"


### PR DESCRIPTION
## Description
This PR adds tests for checking if the sender email on password set success email is valid

Related issue: https://github.com/owncloud/enterprise/issues/2898

## How Has This Been Tested?
CI

## Types of changes
- [x] Tests