### PR TITLE
adjust acceptance test time constant names

### DIFF
--- a/tests/acceptance/features/lib/DisabledUserPage.php
+++ b/tests/acceptance/features/lib/DisabledUserPage.php
@@ -45,7 +45,7 @@ class DisabledUserPage extends OwncloudPage {
 	 */
 	public function waitTillPageIsLoaded(
 		Session $session,
-		$timeout_msec = STANDARDUIWAITTIMEOUTMILLISEC
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
@@ -53,7 +53,7 @@ class DisabledUserPage extends OwncloudPage {
 			if ($this->findAll("xpath", $this->userDisabledXpath)) {
 				break;
 			}
-			\usleep(STANDARDSLEEPTIMEMICROSEC);
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
 		}
 


### PR DESCRIPTION
Old forms of the constant names were deprecated by https://github.com/owncloud/core/pull/32781/commits/db4608ace28ed62a00173021416951fb7ac3d994

Use the new forms that have underscores.