### PR TITLE
Rename openSettingsMenu to openAppSettingsMenu

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -275,7 +275,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theAdminDisablesUserUsingTheWebui($username) {
-		$this->usersPage->openSettingsMenu();
+		$this->usersPage->openAppSettingsMenu();
 		$this->usersPage->setSetting("Show enabled/disabled option");
 		$this->usersPage->disableUser($username);
 	}
@@ -549,7 +549,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theAdministratorChangesTheEmailOfUserToUsingTheWebui($username, $email) {
-		$this->usersPage->openSettingsMenu();
+		$this->usersPage->openAppSettingsMenu();
 		$this->usersPage->setSetting('Show email address');
 		$this->usersPage->changeUserEmail($this->getSession(), $username, $email);
 	}

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -244,7 +244,7 @@ class UsersPage extends OwncloudPage {
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */
-	public function openSettingsMenu() {
+	public function openAppSettingsMenu() {
 		$settingsBtn = $this->find("xpath", $this->settingsBtnXpath);
 		if ($settingsBtn === null) {
 			throw new ElementNotFoundException(
@@ -292,7 +292,7 @@ class UsersPage extends OwncloudPage {
 		}
 
 		if (!$settingContentIsVisible) {
-			$this->openSettingsMenu();
+			$this->openAppSettingsMenu();
 		}
 
 		$xpathLocator = \sprintf($this->settingByTextXpath, $setting);


### PR DESCRIPTION
``openSettingsMenu`` is already a method in ``OwncloudPage``
and
```
class UsersPage extends OwncloudPage
```

The ``openSettingsMenu`` in ``UsersPage`` is different. It opens the "app settings menu" - the tool icon at the bottom left of a webUI page. Whereas ``openSettingsMenu`` in ``OwncloudPage`` opens the menu at the top right which has Logout and the main Settings entries.

I became aware of this because, when running webUI tests locally, I get a PHP warning:
```
PHP Warning:  Declaration of Page\UsersPage::openSettingsMenu() should be compatible with Page\OwncloudPage::openSettingsMenu(Behat\Mink\Session $session) in /home/phil/git/owncloud/core/apps-external/user_management/tests/acceptance/features/lib/UsersPage.php on line 36
PHP Stack trace:
PHP   1. {main}() /home/phil/git/owncloud/core/apps-external/user_management/vendor-bin/behat/vendor/behat/behat/bin/behat:0
PHP   2. Behat\Testwork\Cli\Application->run() /home/phil/git/owncloud/core/apps-external/user_management/vendor-bin/behat/vendor/behat/behat/bin/behat:34
PHP   3. Behat\Testwork\Cli\Application->doRun() /home/phil/git/owncloud/core/apps-external/user_management/vendor-bin/behat/vendor/symfony/console/Application.php:145
...
```

So we should not be "accidentally" overriding the ``openSettingsMenu`` from ``OwncloudPage``