### PR TITLE
Skip tests that are not supposed to work in encryption

### DIFF
--- a/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
@@ -18,6 +18,7 @@ Feature: edit users
     And the user attributes returned by the API should include
     | displayname | New User |
 
+  @skipOnEncryptionType:user-keys
   Scenario: Admin changes the password of the user
     Given user "user0" has been created with default attributes
     And the administrator has browsed to the users page


### PR DESCRIPTION
Some tests in encryption app are failing.
Skip those tests in encryption because those test require an extra step for encryption app to update the encryption keys.