### PR TITLE
Implement "retype password" and adjust confirm password test steps

### DIFF
--- a/css/setpassword.css
+++ b/css/setpassword.css
@@ -13,3 +13,11 @@
 #password {
 	width: 100%;
 }
+
+#retypepassword {
+	width: 100%;
+}
+
+#message {
+	width: 94%;
+}

--- a/js/setpassword.js
+++ b/js/setpassword.js
@@ -5,17 +5,28 @@
 		},
 
 		onClickSetPassword : function(event){
-			event.preventDefault();
 			var passwordObj = $('#password');
-			if (passwordObj.val()){
+			var retypePasswordObj = $('#retypepassword');
+			passwordObj.parent().removeClass('shake');
+			event.preventDefault();
+			if (passwordObj.val() === retypePasswordObj.val()) {
 				$.post(
 					passwordObj.parents('form').attr('action'),
-					{password : passwordObj.val()}
+					{password: passwordObj.val()}
 				).done(function (result) {
 					OCA.UserManagement.SetPassword._resetDone(result);
 				}).fail(function (result) {
 					OCA.UserManagement.SetPassword._onSetPasswordFail(result);
 				});
+			} else {
+				//Password mismatch happened
+				passwordObj.val('');
+				retypePasswordObj.val('');
+				passwordObj.parent().addClass('shake');
+				$('#message').addClass('warning');
+				$('#message').text('Passwords do not match');
+				$('#message').show();
+				passwordObj.focus();
 			}
 		},
 
@@ -59,4 +70,14 @@
 
 $(document).ready(function () {
 	OCA.UserManagement.SetPassword.init();
+	$('#password').keypress(function () {
+		/*
+		 The warning message should be shown only during password mismatch.
+		 Else it should not.
+		 */
+		if (($('#password').val().length >= 0) && ($('#retypepassword').val().length === 0)) {
+			$('#message').removeClass('warning');
+			$('#message').text('');
+		}
+	});
 });

--- a/templates/new_user/setpassword.php
+++ b/templates/new_user/setpassword.php
@@ -25,12 +25,17 @@ script('user_management', 'setpassword');
 <label id="error-message" class="warning" style="display:none"></label>
 <form action="<?php print_unescaped($_['link']) ?>" id="set-password" method="post">
 	<fieldset>
-		<p>
+		<p class="groupbottom<?php if (!empty($_['invalidpassword'])) {
+	?> shake<?php
+} ?>">
 			<label for="password" class="infield"><?php p($l->t('New password')); ?></label>
 			<input type="password" name="password" id="password" value=""
 				   placeholder="<?php p($l->t('New Password')); ?>"
 				   autocomplete="off" autocapitalize="off" autocorrect="off"
 				   required autofocus />
+			<input type="password" name="retypepassword" id="retypepassword" value=""
+				   placeholder="<?php p($l->t('Confirm Password')); ?>"/>
+			<span id='message'></span>
 		</p>
 		<input type="submit" id="submit" value="<?php
 			p($l->t('Please set your password'));

--- a/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
@@ -74,6 +74,20 @@ Feature: add users
       | guiusr1  | simple user-name      |
       | a@-_.'b  | complicated user-name |
 
+  Scenario Outline: user sets his own password but retypes it wrongly after being created with an Email address only
+    When the administrator creates a user with the name "<username>" and the email "guiusr1@owncloud" without a password using the webUI
+    And the administrator logs out of the webUI
+    And the user follows the password set link received by "guiusr1@owncloud" using the webUI
+    And the user has sets password to "%regular%" and confirms with "foo" using the webUI
+    Then user should see password mismatch message displayed on the webUI
+      """
+      Passwords do not match
+      """
+    Examples:
+      | username | comment               |
+      | guiusr1  | simple user-name      |
+      | a@-_.'b  | complicated user-name |
+
   Scenario Outline: webUI refuses to create users with invalid Email addresses
     When the administrator creates a user with the name "guiusr1" and the email "<email>" without a password using the webUI
     Then notifications should be displayed on the webUI with the text

--- a/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addUsers.feature
@@ -62,7 +62,7 @@ Feature: add users
     When the administrator creates a user with the name "<username>" and the email "guiusr1@owncloud" without a password using the webUI
     And the administrator logs out of the webUI
     And the user follows the password set link received by "guiusr1@owncloud" using the webUI
-    And the user sets the password to "%regular%" using the webUI
+    And the user sets the password to "%regular%" and confirms same password using the webUI
     Then the email address "guiusr1@owncloud" should have received an email with the body containing
       """
       Password changed successfully
@@ -103,7 +103,7 @@ Feature: add users
     When the administrator creates a user with the name "guiusr1" and the email "guiusr1@owncloud" without a password using the webUI
     And the administrator logs out of the webUI
     And the user follows the password set link received by "guiusr1@owncloud" using the webUI
-    And the user sets the password to "newpassword" using the webUI
+    And the user sets the password to "newpassword" and confirms same password using the webUI
     And the user follows the password set link received by "guiusr1@owncloud" in Email number 2 using the webUI
     Then the user should be redirected to the general error webUI page with the title "%productname%"
     And an error should be displayed on the general error webUI page saying "The token provided is invalid."
@@ -114,7 +114,7 @@ Feature: add users
     And the administrator creates a user with the name "guiusr1" and the email "correct@owncloud" without a password using the webUI
     And the administrator logs out of the webUI
     And the user follows the password set link received by "correct@owncloud" using the webUI
-    And the user sets the password to "newpassword" using the webUI
+    And the user sets the password to "newpassword" and confirms same password using the webUI
     And the user logs in with username "guiusr1" and password "newpassword" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
@@ -134,7 +134,7 @@ Feature: add users
     And the administrator logs out of the webUI
     And the user follows the password set link received by "mistake@owncloud" using the webUI
     And the user follows the password set link received by "correct@owncloud" using the webUI
-    And the user sets the password to "%regular%" using the webUI
+    And the user sets the password to "%regular%" and confirms same password using the webUI
     And the user logs in with username "guiusr1" and password "%regular%" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
@@ -142,7 +142,7 @@ Feature: add users
     When the administrator creates a user with the name "user1" and the email "guiusr1@owncloud" without a password using the webUI
     And the administrator logs out of the webUI
     And the user follows the password set link received by "guiusr1@owncloud" using the webUI
-    And the user sets the password to "%regular%" using the webUI
+    And the user sets the password to "%regular%" and confirms same password using the webUI
     Then the email address "guiusr1@owncloud" should have received an email with the body containing
       """
       Password changed successfully
@@ -168,7 +168,7 @@ Feature: add users
     When the administrator creates a user with the name "brand-new-user" and the email "bnu@owncloud" without a password using the webUI
     And the administrator logs out of the webUI
     And the user follows the password set link received by "bnu@owncloud" using the webUI
-    And the user sets the password to "<password>" using the webUI
+    And the user sets the password to "<password>" and confirms same password using the webUI
     And the user logs in with username "brand-new-user" and password "<password>" using the webUI
     Then user "brand-new-user" should exist
     And the user should be redirected to a webUI page with the title "Files - %productname%"
@@ -184,5 +184,5 @@ Feature: add users
     When the administrator creates a user with the name "brand-new-user" and the email "bnu@owncloud" without a password using the webUI
     And the administrator logs out of the webUI
     And the user follows the password set link received by "bnu@owncloud" using the webUI
-    And the user sets the password to " " using the webUI
+    And the user sets the password to " " and confirms same password using the webUI
     Then the user should be redirected to a webUI page with the title "%productname%"

--- a/tests/js/setpasswordSpec.js
+++ b/tests/js/setpasswordSpec.js
@@ -21,6 +21,10 @@ describe('OCA.UserManagement.SetPassword tests', function () {
 			'placeholder="New Password"' +
 			'autocomplete="off" autocapitalize="off" autocorrect="off"' +
 			'required autofocus />' +
+			'<input type="password" name="retypepassword" id="retypepassword" value=""' +
+			'placeholder="<"Confirm Password">' +
+			' />' +
+			'<span id="message"></span>' +
 			'</p>' +
 			'<input type="submit" id="submit" value="Please set your password"' +
 			'</fieldset>' +
@@ -47,6 +51,7 @@ describe('OCA.UserManagement.SetPassword tests', function () {
 
 			SetPassword.init();
 			$('#password').val('foo');
+			$('#retypepassword').val('foo');
 			$('#submit').click();
 
 			expect(resultSpy.calledOnce).toEqual(true);
@@ -63,6 +68,7 @@ describe('OCA.UserManagement.SetPassword tests', function () {
 
 			SetPassword.init();
 			$('#password').val('foo');
+			$('#retypepassword').val('foo');
 			$('#submit').click();
 
 			expect(resultSpy.calledOnce).toEqual(true);


### PR DESCRIPTION
Issue #147 
- implement a "retype password" field for the case when the admin creates a new user with just a username and email address. The user follows a link from the email to a UI page where they set their first password.
- adjust accceptance test steps that were changed by core PR https://github.com/owncloud/core/pull/30981