### PR TITLE
don't wait for AJAX when testing invalid quota strings

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -95,6 +95,22 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When the administrator sets/changes the quota of user :username to the invalid string :quota using the webUI
+	 *
+	 * @param string $username
+	 * @param string $quota
+	 *
+	 * @return void
+	 */
+	public function theAdministratorSetsInvalidQuotaOfUserUsingTheWebUI(
+		$username, $quota
+	) {
+		$this->usersPage->setQuotaOfUserTo(
+			$username, $quota, $this->getSession(), false
+		);
+	}
+
+	/**
 	 * @When /^the administrator (attempts to create|creates) a user with the name "([^"]*)" (?:and )?the password "([^"]*)"(?: and the email "([^"]*)")?(?: that is a member of these groups)? using the webUI$/
 	 *
 	 * @param string $attemptTo

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -480,11 +480,14 @@ class UsersPage extends OwncloudPage {
 	 * @param string $username
 	 * @param string $quota text form of quota to be input
 	 * @param Session $session
+	 * @param boolean $valid is the set quota expected to be valid
 	 *
 	 * @throws ElementNotFoundException
 	 * @return void
 	 */
-	public function setQuotaOfUserTo($username, $quota, Session $session) {
+	public function setQuotaOfUserTo(
+		$username, $quota, Session $session, $valid = true
+	) {
 		$userTr = $this->findUserInTable($username);
 		$selectField = $userTr->find('xpath', $this->quotaSelectXpath);
 
@@ -528,7 +531,13 @@ class UsersPage extends OwncloudPage {
 		} else {
 			$selectOption->click();
 		}
-		$this->waitForAjaxCallsToStartAndFinish($session);
+		//a valid quota will be send by AJAX to the server
+		//invalid quotas are checked by JS, so we just wait for the notification to appear
+		if ($valid === true) {
+			$this->waitForAjaxCallsToStartAndFinish($session);
+		} else {
+			$this->waitTillXpathIsVisible("//*[@id='$this->notificationId']");
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
+++ b/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
@@ -36,7 +36,7 @@ Feature: manage user quota
 
   @issue-100
   Scenario Outline: change quota to an invalid value
-    When the administrator changes the quota of user "user1" to "<wished_quota>" using the webUI
+    When the administrator changes the quota of user "user1" to the invalid string "<wished_quota>" using the webUI
     Then a notification should be displayed on the webUI with the text 'Invalid quota value "<wished_quota>"'
     And the quota of user "user1" should be set to "<wished_quota>" on the webUI
     #And the quota of user "user1" should be set to "Default" on the webUI


### PR DESCRIPTION
every time the quota is changed the test used to wait for an AJAX call, but for invalid quota strings that does not happen, they are validated in JS
so in case of an invalid string we should wait for the message to appear not for the AJAX call
fixes #144