### PR TITLE
make quota tests more reliable

### DIFF
--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -498,7 +498,7 @@ class UsersPage extends OwncloudPage {
 				"could not find quota select element"
 			);
 		}
-
+		$selectField->click();
 		$selectOption = $selectField->find(
 			'xpath', \sprintf($this->quotaOptionXpath, $quota)
 		);


### PR DESCRIPTION
need to click the select field before doing other operations
usually the test works without, but not always see #144
but actually the real user also clicks first the select-dropdown before clicking on "Other", so that test sequence is even more realistic

no failure in that setup with 10 runs of Quota tests https://drone.owncloud.com/owncloud/user_management/631
