### PR TITLE
Add missing insulated disablePreviews tags to settingsMenu.feature

### DIFF
--- a/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
+++ b/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
@@ -1,4 +1,4 @@
-@webUI
+@webUI @insulated @disablePreviews
 Feature: add users
   As an admin
   I want to be able to change different settings


### PR DESCRIPTION
Related to issue https://github.com/owncloud/core/issues/34689

Sometimes elements are (sometimes) not clickable, not interactable... during `settingsMenu.feature` scenarios.

It could be related to width of the browser window and the settings on the users page making columns that go off to the right. It could also be a timing issue after clicking the bottom-left settings tool option, and then waiting until the JS has actually enabled the requested column.

I managed to get this this type of issue locally once, but can't reproduce.

Anyway, these extra tags should be on all webUI feature files:
`insulated` - behat-mink-selenium will restart the browser between each scenario - gives better isolation
`disablePreviews` - when not doing test that check for previews display, avoids the slowness of previews being constantly generated and slowly drawing up on the UI (not really relevant to these particular tests, but does reduce the "noise" as the test logs in and the files page is displayed)