### PR TITLE
Wait for settings menu animation on users page

### DIFF
--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -305,6 +305,15 @@ class UsersPage extends OwncloudPage {
 			);
 		}
 		$settingsBtn->click();
+		// At this point isVisible() on the settings menu returns true
+		// But the settings menu animation is happening.
+		// If we try to click a setting before the animation is finished
+		// then the click is not effective.
+		// This results in intermittent test fails, because the expected
+		// setting does not happen.
+		// ToDo: some day sort out how to query the settings menu div in a loop
+		//       and wait until the animation has stopped
+		\sleep(1);
 	}
 
 	/**


### PR DESCRIPTION
There are webUI tests on the users page that adjust the settings and then check that columns are visible or not, or try to enter password or email address etc. These tests have become intermittently unreliable. I think faster test systems will see this timing issue more often.

After investigation, I realized that the settings menu on the users page opens with an animation. The observed behavior is that if the test tries to click a setting checkbox before the animation is finished, then the click is not effective, but does not return and error.

However, as soon as the test clicks to open the settings menu, `isVisible()` on the settings menu returns true - although the menu might still be animating itself.

Basically it's a PITA. We could design some sort of JS query to send in a loop to try and see if the menu is still in an "animating" state. Or we can repeatedly query the size/position of the menu div and wait until it has been "steady" for "a while". They are the 2 common approaches that others take to try and cope with waiting for animations. That will all take time to work out the gory details.

At the moment this is causing significant percentages of "random" test fails, which is not "a good thing". So put in a 1 second sleep (which I hate to do)