### PR TITLE
Drop PHP 5.6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -200,12 +200,6 @@ matrix:
       NEED_SERVER: true
       NEED_INSTALL_APP: true
 
-    #  - TEST_SUITE: phpunit
-    #    PHP_VERSION: 5.6
-    #    OC_VERSION: daily-stable10-qa
-    #    NEED_SERVER: true
-    #    NEED_INSTALL_APP: true
-
     #acceptance tests
     - TEST_SUITE: web-acceptance
       OC_VERSION: daily-master-qa


### PR DESCRIPTION
core stable10 no longer supports PHP 5.6
https://github.com/owncloud/core/pull/34698

Note: this only had a commented-out matrix entry