### PR TITLE
Adjust composer files for 'drop PHP 5.6'

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<version>0.0.1</version>
 	<category>tools</category>
 	<dependencies>
-		<owncloud min-version="10.0" max-version="11.0" />
+		<owncloud min-version="10.2" max-version="11.0" />
 	</dependencies>
 	<namespace>UserManagement</namespace>
 	<navigation role="admin,sub-admin">

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "config" : {
         "optimize-autoloader": true,
         "platform": {
-            "php": "5.6.37"
+            "php": "7.0.8"
         }
     },
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "88eb3dc9410190e1f67c88809e8f32f8",
+    "content-hash": "9955fb524b3476f5712df8c941c19db6",
     "packages": [],
     "packages-dev": [
         {
@@ -57,6 +57,6 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6.37"
+        "php": "7.0.8"
     }
 }


### PR DESCRIPTION
- [x] adjust local `composer` files to PHP 7.0.8
- [x] bump app core min-version to `10.2`

because the app is now being tested only against core `stable10` upcoming `10.2` that has dropped PHP 5.6 support.
