### PR TITLE
Catch waitTillXpathIsVisible() in setQuotaOfUserTo()

### DIFF
--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -545,7 +545,19 @@ class UsersPage extends OwncloudPage {
 		if ($valid === true) {
 			$this->waitForAjaxCallsToStartAndFinish($session);
 		} else {
-			$this->waitTillXpathIsVisible("//*[@id='$this->notificationId']");
+			try {
+				$this->waitTillXpathIsVisible(
+					"//*[@id='$this->notificationId']", 1000
+				);
+			} catch (\Exception $e) {
+				// Sometimes the notification is not "noticed".
+				// Later steps are responsible for caring if a notification
+				// is actually seen, so just output some information
+				$message = __METHOD__ . " INFORMATION: notificationId '" .
+					$this->notificationId . "' did not become visible";
+				echo $message;
+				\error_log($message);
+			}
 		}
 	}
 

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -86,6 +86,8 @@ class UsersPage extends OwncloudPage {
 	protected $deleteNotConfirmBtnXpath
 		= ".//div[contains(@class, 'oc-dialog-buttonrow twobuttons') and not(ancestor::div[contains(@style, 'display: none')])]//button[text()='No']";
 
+	protected $userNameFieldCss = ".name";
+
 	protected $editUserDisplayNameBtnXpath = ".//td[@class='displayName']/img";
 	protected $editUserDisplayNameFieldXpath = "/td[@class='displayName']/input";
 
@@ -110,7 +112,7 @@ class UsersPage extends OwncloudPage {
 		$userTrs = $this->findAll('xpath', $this->userTrXpath);
 
 		foreach ($userTrs as $userTr) {
-			$user = $userTr->find("css", ".name");
+			$user = $userTr->find("css", $this->userNameFieldCss);
 			if ($this->getTrimmedText($user) === $username) {
 				return $userTr;
 			}
@@ -836,11 +838,19 @@ class UsersPage extends OwncloudPage {
 		Session $session,
 		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC
 	) {
+		// There is always at least the "admin" user in the displayed list of users
+		// So wait for the user list to have at least 1 real user in it
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);
 		while ($currentTime <= $end) {
-			if ($this->findById($this->groupListId) !== null) {
-				break;
+			$userTrs = $this->findAll('xpath', $this->userTrXpath);
+			foreach ($userTrs as $userTr) {
+				$user = $userTr->find("css", $this->userNameFieldCss);
+				if ($this->getTrimmedText($user) !== '') {
+					// We have found a real user
+					// (note that there is a hidden empty "template" row)
+					break 2;
+				}
 			}
 			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
 			$currentTime = \microtime(true);
@@ -848,10 +858,8 @@ class UsersPage extends OwncloudPage {
 
 		if ($currentTime > $end) {
 			throw new \Exception(
-				__METHOD__ . " timeout waiting for users page to load"
+				__METHOD__ . " timeout waiting for user list to load on users page"
 			);
 		}
-
-		$this->waitForOutstandingAjaxCalls($session);
 	}
 }


### PR DESCRIPTION
1) `setQuotaOfUserTo()` is responsible for attempting to set the quota of the user on the webUI. When the given quota is expected to be invalid, then it tries to wait for the "invalid" to be actioned on the webUI (so that the page will be "ready" for the next action). It looks for a notification to "pop up".

That logic is fine in general. But if the notification element does not become visible (for whatever reason) then an exception should not be thrown. At this point in the code the purpose of `waitTillXpathIsVisible()` is only to provide a reasonable wait for the page to be "ready again".

- specify just a shorter maximum wait for `notificationId` to be visible (it is a local JS thing that happens, so it does not have to wait for a round-trip AJAX to the server)
- catch the exception that is thrown after the timeout, and just log an information message so we can see that this happens

2) when `UsersPage` loads, we waited for `groupListId` to be there. That was OK, because that means the page itself has "arrived" properly with the pre-populated groups. But after that there is AJAX that does stuff like:
```
http://172.17.0.1:8080/index.php/core/ajax/appconfig.php?app=core&key=umgmt_set_password&defaultValue=false&action=getValue
http://172.17.0.1:8080/index.php/apps/user_management/users?offset=0&limit=200&gid=&pattern=
```
Sometimes we would see and wait for that in `waitForOutstandingAjaxCalls()` but sometimes we missed it (looking too early...)

So make `waitTillPageIsLoaded()` wait until it sees at least 1 actual user in the user list - that ensures that we are after the AJAX call to load the first chunk of the user list, and that user(s) are really displayed.