### PR TITLE
Reenable invalid quota notification check

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -225,6 +225,78 @@ matrix:
       BEHAT_SUITE: webUISettingsMenu
       USE_EMAIL: true
 
+    - TEST_SUITE: web-acceptance
+      OC_VERSION: daily-master-qa
+      PHP_VERSION: 7.1
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: webUIManageQuota
+      USE_EMAIL: true
+
+    - TEST_SUITE: web-acceptance
+      OC_VERSION: daily-master-qa
+      PHP_VERSION: 7.1
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: webUIManageQuota
+      USE_EMAIL: true
+
+    - TEST_SUITE: web-acceptance
+      OC_VERSION: daily-master-qa
+      PHP_VERSION: 7.1
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: webUIManageQuota
+      USE_EMAIL: true
+
+    - TEST_SUITE: web-acceptance
+      OC_VERSION: daily-master-qa
+      PHP_VERSION: 7.1
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: webUIManageQuota
+      USE_EMAIL: true
+
+    - TEST_SUITE: web-acceptance
+      OC_VERSION: daily-master-qa
+      PHP_VERSION: 7.1
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: webUIManageQuota
+      USE_EMAIL: true
+
+    - TEST_SUITE: web-acceptance
+      OC_VERSION: daily-master-qa
+      PHP_VERSION: 7.1
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: webUIManageQuota
+      USE_EMAIL: true
+
+    - TEST_SUITE: web-acceptance
+      OC_VERSION: daily-master-qa
+      PHP_VERSION: 7.1
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: webUIManageQuota
+      USE_EMAIL: true
+
+    - TEST_SUITE: web-acceptance
+      OC_VERSION: daily-master-qa
+      PHP_VERSION: 7.1
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: webUIManageQuota
+      USE_EMAIL: true
+
+    - TEST_SUITE: web-acceptance
+      OC_VERSION: daily-master-qa
+      PHP_VERSION: 7.1
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: webUIManageQuota
+      USE_EMAIL: true
+
 #   - TEST_SUITE: web-acceptance
 #     OC_VERSION: daily-stable10-qa
 #     PHP_VERSION: 7.1

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -69,6 +69,17 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When sleep :seconds in the user management test
+	 *
+	 * @param string $seconds
+	 *
+	 * @return void
+	 */
+	public function sleepInTheUserManagementTest($seconds) {
+		\sleep($seconds);
+	}
+
+	/**
 	 * @When the user/administrator browses to the users page
 	 * @Given the user/administrator has browsed to the users page
 	 *

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -861,5 +861,7 @@ class UsersPage extends OwncloudPage {
 				__METHOD__ . " timeout waiting for user list to load on users page"
 			);
 		}
+
+		$this->waitForOutstandingAjaxCalls($session);
 	}
 }

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -863,5 +863,10 @@ class UsersPage extends OwncloudPage {
 		}
 
 		$this->waitForOutstandingAjaxCalls($session);
+
+		// We have tried long enough, and cannot yet find what is the extra thing
+		// that we have to wait for until the page is properly loaded.
+		// ToDo: sort out the real reason that we need to sleep here.
+		\sleep(1);
 	}
 }

--- a/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
+++ b/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
@@ -37,7 +37,7 @@ Feature: manage user quota
   @issue-100
   Scenario Outline: change quota to an invalid value
     When the administrator changes the quota of user "user1" to the invalid string "<wished_quota>" using the webUI
-    #Then a notification should be displayed on the webUI with the text 'Invalid quota value "<wished_quota>"'
+    Then a notification should be displayed on the webUI with the text 'Invalid quota value "<wished_quota>"'
     And the quota of user "user1" should be set to "<wished_quota>" on the webUI
     #And the quota of user "user1" should be set to "Default" on the webUI
     Examples:

--- a/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
+++ b/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
@@ -36,7 +36,7 @@ Feature: manage user quota
 
   @issue-100
   Scenario Outline: change quota to an invalid value
-    Given sleep 1 in the user management test
+    #Given sleep 1 in the user management test
     When the administrator changes the quota of user "user1" to the invalid string "<wished_quota>" using the webUI
     Then a notification should be displayed on the webUI with the text 'Invalid quota value "<wished_quota>"'
     And the quota of user "user1" should be set to "<wished_quota>" on the webUI

--- a/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
+++ b/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
@@ -36,6 +36,7 @@ Feature: manage user quota
 
   @issue-100
   Scenario Outline: change quota to an invalid value
+    Given sleep 1 in the user management test
     When the administrator changes the quota of user "user1" to the invalid string "<wished_quota>" using the webUI
     Then a notification should be displayed on the webUI with the text 'Invalid quota value "<wished_quota>"'
     And the quota of user "user1" should be set to "<wished_quota>" on the webUI


### PR DESCRIPTION
We have improved some "wait till page is loaded" and `waitTillXpathIsVisible` checks (PRs #162 #163 ) 
This test step to check the notifications might work more reliably.