### PR TITLE
Wait longer in users page wait till page is loaded

### DIFF
--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -861,5 +861,12 @@ class UsersPage extends OwncloudPage {
 				__METHOD__ . " timeout waiting for user list to load on users page"
 			);
 		}
+
+		$this->waitForOutstandingAjaxCalls($session);
+
+		// We have tried long enough, and cannot yet find what is the extra thing
+		// that we have to wait for until the page is properly loaded.
+		// ToDo: sort out the real reason that we need to sleep here.
+		\sleep(1);
 	}
 }

--- a/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
+++ b/tests/acceptance/features/webUIManageQuota/manageUserQuota.feature
@@ -37,7 +37,7 @@ Feature: manage user quota
   @issue-100
   Scenario Outline: change quota to an invalid value
     When the administrator changes the quota of user "user1" to the invalid string "<wished_quota>" using the webUI
-    #Then a notification should be displayed on the webUI with the text 'Invalid quota value "<wished_quota>"'
+    Then a notification should be displayed on the webUI with the text 'Invalid quota value "<wished_quota>"'
     And the quota of user "user1" should be set to "<wished_quota>" on the webUI
     #And the quota of user "user1" should be set to "Default" on the webUI
     Examples:


### PR DESCRIPTION
After waiting for the AJAX with the users list to come in `UsersPage` `waitTillPageIsLoaded()` we know that we have some real users (at least "admin") listed on the page. But when we continue at that time to "get on with the test steps" then we often have trouble with the notification popup not happening (at least not being found).

Adding `waitForOutstandingAjaxCalls()` is a reasonable thing, but actually that returns "straight away" because the AJAX calls have finished. So that is not the complete solution.

For now, we need to get this reliable, so we also add `sleep(1)` to the end of `UsersPage` `waitTillPageIsLoaded()`. I have run the `webUIManageQuota` suite over-and-over and it passes 100% with the `sleep(1)`. Without the sleep, then this step fails a lot to find the notification:
```
Then a notification should be displayed on the webUI with the text 'Invalid quota value "<wished_quota>"'
```

So the workaround for now is to put the sleep in the code.
