### PR TITLE
disable integrity check

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -30,6 +30,7 @@ pipeline:
       - php occ config:system:set trusted_domains 1 --value=server
       - php occ config:system:set trusted_domains 2 --value=federated
       - php occ log:manage --level 0
+      - php occ config:system:set --value true --type boolean integrity.check.disabled
     when:
       matrix:
         NEED_INSTALL_APP: true

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -861,12 +861,5 @@ class UsersPage extends OwncloudPage {
 				__METHOD__ . " timeout waiting for user list to load on users page"
 			);
 		}
-
-		$this->waitForOutstandingAjaxCalls($session);
-
-		// We have tried long enough, and cannot yet find what is the extra thing
-		// that we have to wait for until the page is properly loaded.
-		// ToDo: sort out the real reason that we need to sleep here.
-		\sleep(1);
 	}
 }


### PR DESCRIPTION
The real problem for #167 is the failing integrity check see https://github.com/owncloud/core/issues/34787
disabling it for now
with disabled check tests pass reliably even without the waiting see #168 