### PR TITLE
Remove ToDo message about sleep

### DIFF
--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -313,8 +313,7 @@ class UsersPage extends OwncloudPage {
 		// then the click is not effective.
 		// This results in intermittent test fails, because the expected
 		// setting does not happen.
-		// ToDo: some day sort out how to query the settings menu div in a loop
-		//       and wait until the animation has stopped
+		// Ref: https://github.com/owncloud/core/issues/34689
 		\sleep(1);
 	}
 


### PR DESCRIPTION
Issue https://github.com/owncloud/core/issues/34689

See the issue discussion. We know the animation timing here, and it is not worthwhile to dig into the detail of tracking the animation state with Jquery/JavaScript... So remove the ToDo and just reference the issue discussion.