### PR TITLE
Fix changeUserPassword function in users page page object

### DIFF
--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -738,9 +738,9 @@ class UsersPage extends OwncloudPage {
 		try {
 			$editPasswordInput->focus();
 			$editPasswordInput->setValue($password . "\n");
-			$this->waitForAjaxCallsToStartAndFinish($session);
 		} catch (StaleElementReference $e) {
 		}
+		$this->waitForAjaxCallsToStartAndFinish($session);
 	}
 
 	/**


### PR DESCRIPTION
Fix the function to change user's password in UserPage page object in acceptance test.

This function worked fine before but if we had wanted to do some more UI tests after this step in acceptance test, It would throw error because `waitForAjaxCallsToStartAndFinish` would never run because of the `StaleElementReference` exception.