### PR TITLE
Use html body for message sent via email for password change

### DIFF
--- a/lib/Controller/UsersController.php
+++ b/lib/Controller/UsersController.php
@@ -723,11 +723,14 @@ class UsersController extends Controller {
 		if ($email !== '') {
 			$tmpl = new \OC_Template('core', 'lostpassword/notify');
 			$msg = $tmpl->fetchPage();
+			$tmplAlt = new \OC_Template('core', 'lostpassword/altnotify');
+			$msgAlt = $tmplAlt->fetchPage();
 
 			$message = $this->mailer->createMessage();
 			$message->setTo([$email => $userId]);
 			$message->setSubject($this->l10n->t('%s password changed successfully', [$this->defaults->getName()]));
-			$message->setPlainBody($msg);
+			$message->setPlainBody($msgAlt);
+			$message->setHtmlBody($msg);
 			$message->setFrom([$this->fromMailAddress => $this->defaults->getName()]);
 			$this->mailer->send($message);
 		}

--- a/tests/unit/UsersControllerTest.php
+++ b/tests/unit/UsersControllerTest.php
@@ -2310,6 +2310,9 @@ class UsersControllerTest extends TestCase {
 			->method('setSubject')
 			->willReturn($message);
 		$message->expects($this->once())
+			->method('setHtmlBody')
+			->willReturn($message);
+		$message->expects($this->once())
 			->method('setPlainBody')
 			->willReturn($message);
 		$message->expects($this->once())


### PR DESCRIPTION
Use html body for message sent via email
for password change.

Signed-off-by: Sujith H <sharidasan@owncloud.com>