### PR TITLE
Test user count is updated when user is removed from or added to a group

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -166,7 +166,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 			$attemptTo, $username, null, $email, $groupsTable
 		);
 	}
-	
+
 	/**
 	 *
 	 * @When the administrator deletes the group named :name using the webUI and confirms the deletion using the webUI
@@ -484,7 +484,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	) {
 		foreach ($table as $row) {
 			$userLastLogin = $this->usersPage->getLastLoginOfUser($row['username']);
-			
+
 			Assert::assertContains($row['last login'], $userLastLogin);
 		}
 	}
@@ -626,5 +626,33 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 		$this->usersPage->openAppSettingsMenu();
 		$this->usersPage->setSetting('Show email address');
 		$this->usersPage->changeUserEmail($this->getSession(), $username, $email);
+	}
+
+	/**
+	 * @Then /^the user count of group "([^"]*)" should display (\d+) users on the webUI$/
+	 *
+	 * @param string $group
+	 * @param int $count
+	 *
+	 * @return void
+	 */
+	public function theUserCountOfGroupShouldDisplayUsersOnTheWebUI($group, $count) {
+		$expectedCount = (int) $count;
+		$actualCount = $this->usersPage->getUserCountOfGroup($group);
+		PHPUnit\Framework\Assert::assertEquals($expectedCount, $actualCount);
+	}
+
+	/**
+	 * @Then the user count of group :group should not be displayed on the webUI
+	 *
+	 * @param string $group
+	 *
+	 * @return void
+	 */
+	public function theUserCountOfGroupShouldNotBeDisplayedOnTheWebui($group) {
+		$count = $this->usersPage->getUserCountOfGroup($group);
+		PHPUnit\Framework\Assert::assertNull(
+			$count, "Failed asserting that user count of group $group is not displayed"
+		);
 	}
 }

--- a/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
@@ -58,3 +58,19 @@ Feature: Add group
       | "✍"                          |
       | "⛷"                           |
       | "⛹"                           |
+
+  Scenario: adding multiple users to a group
+    Given these users have been created without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+      | user2    |
+    And group "grp1" has been created
+    And the administrator has reloaded the users page
+    When the administrator adds user "user0" to group "grp1" using the webUI
+    And the administrator adds user "user1" to group "grp1" using the webUI
+    Then the user count of group "grp1" should display 2 users on the webUI
+    When the administrator adds user "user2" to group "grp1" using the webUI
+    Then the user count of group "grp1" should display 3 users on the webUI
+    When the administrator reloads the users page
+    Then the user count of group "grp1" should display 3 users on the webUI

--- a/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
@@ -110,3 +110,22 @@ Feature: edit users
       | New-Group | new-group | NEW-GROUP |
       | new-group | NEW-GROUP | New-Group |
       | NEW-GROUP | New-Group | new-group |
+
+  Scenario: removing multiple users from a group
+    Given these users have been created without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+      | user2    |
+    And group "grp1" has been created
+    And user "user0" has been added to group "grp1"
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
+    And the administrator has browsed to the users page
+    When the administrator removes user "user0" from group "grp1" using the webUI
+    And the administrator removes user "user1" from group "grp1" using the webUI
+    Then the user count of group "grp1" should display 1 users on the webUI
+    When the administrator removes user "user2" from group "grp1" using the webUI
+    Then the user count of group "grp1" should not be displayed on the webUI
+    When the administrator reloads the users page
+    Then the user count of group "grp1" should not be displayed on the webUI


### PR DESCRIPTION
## Description
Test user count is updated (without refreshing the page) when the user is removed from or added to a group

## Related Issue
https://github.com/owncloud/core/issues/35289

## How Has This Been Tested?
🤖

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link>