### PR TITLE
Added description for the user settings section

### DIFF
--- a/templates/main.php
+++ b/templates/main.php
@@ -41,14 +41,14 @@ translation('settings');
 	<?php print_unescaped($this->inc('part.grouplist')); ?>
 	<div id="app-settings">
 		<div id="app-settings-header">
-			<button class="settings-button" tabindex="0" data-apps-slide-toggle="#app-settings-content"></button>
+			<button class="settings-button" tabindex="0" data-apps-slide-toggle="#app-settings-content"><?php p($l->t('Settings'));?></button>
 		</div>
 		<div id="app-settings-content">
 			<?php print_unescaped($this->inc('part.setquota')); ?>
 
 			<div id="userlistoptions">
 				<p>
-					<input type="checkbox" name="IsEnabled" value="IsEnabled" id="CheckboxIsEnabled" 
+					<input type="checkbox" name="IsEnabled" value="IsEnabled" id="CheckboxIsEnabled"
 						class="checkbox" <?php if ($_['show_is_enabled'] === 'true') {
 	print_unescaped('checked="checked"');
 } ?> />
@@ -57,7 +57,7 @@ translation('settings');
 					</label>
 				</p>
 				<p>
-					<input type="checkbox" name="StorageLocation" value="StorageLocation" id="CheckboxStorageLocation" 
+					<input type="checkbox" name="StorageLocation" value="StorageLocation" id="CheckboxStorageLocation"
 						class="checkbox" <?php if ($_['show_storage_location'] === 'true') {
 	print_unescaped('checked="checked"');
 } ?> />


### PR DESCRIPTION
## Description
Like in the Files view I add the description to the settings icon.

## Motivation and Context
The settings icon was often overlooked. I think we may prevent that with the description like in the Files app.

## How Has This Been Tested?
Manual tested

## Screenshots:
Before:
![before](https://user-images.githubusercontent.com/33026403/61451665-2ede9280-a95a-11e9-8826-b7b85495cf34.png)

After:
![after](https://user-images.githubusercontent.com/33026403/61451681-37cf6400-a95a-11e9-831c-ff0b968ab349.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 