### PR TITLE
Remove stable10 test jobs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,7 +22,7 @@ pipeline:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     commands:
-      - git clone -b stable10 --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
+      - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
       - cd /var/www/owncloud/testrunner
       - make install-composer-deps
       - make vendor-bin-deps
@@ -286,35 +286,3 @@ matrix:
       BEHAT_SUITE: webUISettingsMenu
       USE_EMAIL: true
       NEED_TARBALL: true
-
-#   - TEST_SUITE: web-acceptance
-#     OC_VERSION: daily-stable10-qa
-#     PHP_VERSION: 7.1
-#     NEED_SERVER: true
-#     NEED_INSTALL_APP: true
-#     BEHAT_SUITE: webUIAddUsers
-#     USE_EMAIL: true
-#
-#   - TEST_SUITE: web-acceptance
-#     OC_VERSION: daily-stable10-qa
-#     PHP_VERSION: 7.1
-#     NEED_SERVER: true
-#     NEED_INSTALL_APP: true
-#     BEHAT_SUITE: webUIManageQuota
-#     USE_EMAIL: true
-#
-#   - TEST_SUITE: web-acceptance
-#     OC_VERSION: daily-stable10-qa
-#     PHP_VERSION: 7.1
-#     NEED_SERVER: true
-#     NEED_INSTALL_APP: true
-#     BEHAT_SUITE: webUIManageUsersGroups
-#     USE_EMAIL: true
-#
-#   - TEST_SUITE: web-acceptance
-#     OC_VERSION: daily-stable10-qa
-#     PHP_VERSION: 7.1
-#     NEED_SERVER: true
-#     NEED_INSTALL_APP: true
-#     BEHAT_SUITE: webUISettingsMenu
-#     USE_EMAIL: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ pipeline:
   install-server:
     image: owncloudci/core
     pull: true
+    exclude: "apps/user_management"
     version: ${OC_VERSION}
     db_type: mysql
     db_name: owncloud


### PR DESCRIPTION
Issue https://github.com/owncloud/core/issues/35777

The old core `stable10` is now `master`

There is likely to be trouble here, because there is no longer any core branch that has `user_management` removed.